### PR TITLE
Add a lightweight version written with declarative macros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,12 @@ jobs:
     - name: Check code format
       run: cargo fmt --all -- --check
     - name: Clippy
-      run: cargo clippy --target ${{ matrix.targets }} --all-features
+      run: cargo clippy --workspace --target ${{ matrix.targets }} --all-features
     - name: Build
-      run: cargo build --target ${{ matrix.targets }} --all-features
+      run: cargo build --workspace --target ${{ matrix.targets }} --all-features
     - name: Unit test
       if: ${{ matrix.targets == 'x86_64-unknown-linux-gnu' && matrix.rust-toolchain != '${{ needs.metadata.outputs.rust_version }}' }}
-      run: cargo test --target ${{ matrix.targets }} -- --nocapture
+      run: cargo test --workspace --target ${{ matrix.targets }} -- --nocapture
 
   doc:
     runs-on: ubuntu-latest

--- a/crate_interface_lite/Cargo.toml
+++ b/crate_interface_lite/Cargo.toml
@@ -1,24 +1,13 @@
-[workspace]
-members = ["crate_interface_lite"]
-
 [package]
-name = "crate_interface"
-version = "0.1.4"
+name = "crate_interface_lite"
+version = "0.1.0"
 edition = "2021"
-authors = ["Yuekai Jia <equation618@gmail.com>"]
+authors = ["Yuekai Jia <equation618@gmail.com>", "Loi Chyan <loichyan@outlook.com>"]
 description = "Provides a way to define an interface (trait) in a crate, but can implement or use it in any crate."
 license = "GPL-3.0-or-later OR Apache-2.0 OR MulanPSL-2.0"
 homepage = "https://github.com/arceos-org/arceos"
 repository = "https://github.com/arceos-org/crate_interface"
-documentation = "https://docs.rs/crate_interface"
+documentation = "https://docs.rs/crate_interface_lite"
 keywords = ["arceos", "api", "macro"]
 categories = ["development-tools::procedural-macro-helpers", "no-std"]
 rust-version = "1.57"
-
-[dependencies]
-proc-macro2 = "1.0"
-quote = "1.0"
-syn = { version = "2.0", features = ["full"] }
-
-[lib]
-proc-macro = true

--- a/crate_interface_lite/README.md
+++ b/crate_interface_lite/README.md
@@ -38,3 +38,61 @@ assert_eq!(
     "Hello, rust 456!"
 );
 ```
+
+## Comparison with [crate_interface](https://crates.io/crates/crate_interface)
+
+### Similar: APIs
+
+The public APIs are almost the same as crate_interface. One major difference is
+that you cannot use the exported macros as attributes.
+
+```rust,ignore
+// With crate_interface...
+#[crate_interface::def_interface]
+pub trait HelloIf {
+    fn hello(name: &str, id: usize) -> String;
+}
+// With crate_interface_lite...
+crate_interface_lite::def_interface!(
+    pub trait HelloIf {
+        fn hello(name: &str, id: usize) -> String;
+    }
+);
+```
+
+### Different: No proc-macro related dependencies
+
+This is the major reason to use this crate, as it would result in a tidier
+dependency tree of your project and slightly speed up the compilation. However,
+if you already have proc-macro related dependencies in your crate’s dependency
+graph, there is almost no benefit from using this crate.
+
+### Different: No support for method receivers
+
+Unlike `crate_interface::def_interface`, the macro in this crate does not support
+method receivers, namely `self`, `&self`, `&mut self`, etc. But in most cases, you
+don't need them, since the `impl_interface` is often applied to an unit struct.
+
+```rust,compile_fail
+crate_interface_lite::def_interface!(
+    pub trait HelloIf {
+        fn hello(self, name: &str, id: usize) -> String;
+        //       ^^^^ Not supported!
+    }
+);
+```
+
+### Different: No support for default implementations
+
+The `def_interface` in this crate does not support default implementations of
+trait functions. In the future, we may support using default implementations as
+fallbacks when no other implementations are provided.
+
+```rust,compile_fail
+crate_interface_lite::def_interface!(
+    pub trait HelloIf {
+        fn hello(self, name: &str, id: usize) -> String { todo!() }
+        //                                              ^^^^^^^^^^^ Not supported!
+    }
+);
+```

--- a/crate_interface_lite/README.md
+++ b/crate_interface_lite/README.md
@@ -1,6 +1,6 @@
 # crate_interface_lite
 
-[![Crates.io](https://img.shields.io/crates/v/crate_interface)](https://crates.io/crates/crate_interface_lite)
+[![Crates.io](https://img.shields.io/crates/v/crate_interface_lite)](https://crates.io/crates/crate_interface_lite)
 [![Docs.rs](https://docs.rs/crate_interface/badge.svg)](https://docs.rs/crate_interface_lite)
 [![CI](https://github.com/arceos-org/crate_interface/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/arceos-org/crate_interface/actions/workflows/ci.yml)
 

--- a/crate_interface_lite/README.md
+++ b/crate_interface_lite/README.md
@@ -91,8 +91,8 @@ fallbacks when no other implementations are provided.
 ```rust,compile_fail
 crate_interface_lite::def_interface!(
     pub trait HelloIf {
-        fn hello(self, name: &str, id: usize) -> String { todo!() }
-        //                                              ^^^^^^^^^^^ Not supported!
+        fn hello(name: &str, id: usize) -> String { todo!() }
+        //                                        ^^^^^^^^^^^ Not supported!
     }
 );
 ```

--- a/crate_interface_lite/README.md
+++ b/crate_interface_lite/README.md
@@ -1,0 +1,40 @@
+# crate_interface_lite
+
+[![Crates.io](https://img.shields.io/crates/v/crate_interface)](https://crates.io/crates/crate_interface_lite)
+[![Docs.rs](https://docs.rs/crate_interface/badge.svg)](https://docs.rs/crate_interface_lite)
+[![CI](https://github.com/arceos-org/crate_interface/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/arceos-org/crate_interface/actions/workflows/ci.yml)
+
+A lightweight version of [crate_interface](https://crates.io/crates/crate_interface)
+written with declarative macros.
+
+## Example
+
+```rust
+// Define the interface
+crate_interface_lite::def_interface!(
+    pub trait HelloIf {
+        fn hello(name: &str, id: usize) -> String;
+    }
+);
+
+// Implement the interface in any crate
+struct HelloIfImpl;
+crate_interface_lite::impl_interface!(
+    impl HelloIf for HelloIfImpl {
+        fn hello(name: &str, id: usize) -> String {
+            format!("Hello, {} {}!", name, id)
+        }
+    }
+);
+
+// Call `HelloIfImpl::hello` in any crate
+use crate_interface_lite::call_interface;
+assert_eq!(
+    call_interface!(HelloIf::hello("world", 123)),
+    "Hello, world 123!"
+);
+assert_eq!(
+    call_interface!(HelloIf::hello, "rust", 456), // another calling style
+    "Hello, rust 456!"
+);
+```

--- a/crate_interface_lite/src/lib.rs
+++ b/crate_interface_lite/src/lib.rs
@@ -12,10 +12,11 @@
 /// See the [crate-level documentation](crate) for more details.
 #[macro_export]
 macro_rules! def_interface {
-    ($vis:vis trait $name:ident {$(
+    ($(#[$attr:meta])* $vis:vis trait $name:ident {$(
         $(#[$fn_attr:meta])*
         fn $fn_name:ident($($arg_name:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)?;
     )*}) => {
+        $(#[$attr])*
         $vis trait $name {$(
             $(#[$fn_attr])*
             fn $fn_name($($arg_name: $arg_ty,)*) $(-> $ret_ty)?;
@@ -45,10 +46,11 @@ macro_rules! def_interface {
 /// See the [crate-level documentation](crate) for more details.
 #[macro_export]
 macro_rules! impl_interface {
-    (impl $interface:ident for $target:ident {$(
+    ($(#[$attr:meta])* impl $interface:ident for $target:ident {$(
         $(#[$fn_attr:meta])*
         fn $fn_name:ident($($arg_name:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)? { $($body:tt)* }
     )*}) => {
+        $(#[$attr])*
         impl $interface for $target {$(
             $(#[$fn_attr])*
             fn $fn_name($($arg_name: $arg_ty,)*) $(-> $ret_ty)? {

--- a/crate_interface_lite/src/lib.rs
+++ b/crate_interface_lite/src/lib.rs
@@ -99,6 +99,7 @@ macro_rules! __interface_fn {
 }
 
 /// NON-PUBLIC APIs
+#[doc(hidden)]
 pub mod r#priv {
     /// The default implementor for all defined interfaces.
     pub struct DefaultImpl;

--- a/crate_interface_lite/src/lib.rs
+++ b/crate_interface_lite/src/lib.rs
@@ -3,8 +3,8 @@
 
 /// Define an interface.
 ///
-/// This attribute should be added above the definition of a trait. All traits
-/// that use the attribute cannot have the same name.
+/// This attribute should be used with a `trait` item. All traits that use the
+/// attribute cannot have the same name.
 ///
 /// It is not necessary to define it in the same crate as the implementation,
 /// but it is required that these crates are linked together.
@@ -36,8 +36,8 @@ macro_rules! def_interface {
 
 /// Implement the interface for a struct.
 ///
-/// This attribute should be added above the implementation of a trait for a
-/// struct, and the trait must be defined with [`def_interface!`].
+/// This attribute should be use with a `impl` item of a trait for a struct, and
+/// the trait must be defined with [`def_interface!`].
 ///
 /// It is not necessary to implement it in the same crate as the definition, but
 /// it is required that these crates are linked together.
@@ -62,7 +62,7 @@ macro_rules! impl_interface {
     };
 }
 
-/// Call a function in the interface.
+/// Call a function in a defined interface.
 ///
 /// It is not necessary to call it in the same crate as the implementation, but
 /// it is required that these crates are linked together.
@@ -98,5 +98,6 @@ macro_rules! __interface_fn {
 
 /// NON-PUBLIC APIs
 pub mod r#priv {
+    /// The default implementor for all defined interfaces.
     pub struct DefaultImpl;
 }

--- a/crate_interface_lite/src/lib.rs
+++ b/crate_interface_lite/src/lib.rs
@@ -1,0 +1,102 @@
+#![doc = include_str!("../README.md")]
+#![no_std]
+
+/// Define an interface.
+///
+/// This attribute should be added above the definition of a trait. All traits
+/// that use the attribute cannot have the same name.
+///
+/// It is not necessary to define it in the same crate as the implementation,
+/// but it is required that these crates are linked together.
+///
+/// See the [crate-level documentation](crate) for more details.
+#[macro_export]
+macro_rules! def_interface {
+    ($vis:vis trait $name:ident {$(
+        $(#[$fn_attr:meta])*
+        fn $fn_name:ident($($arg_name:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)?;
+    )*}) => {
+        $vis trait $name {$(
+            $(#[$fn_attr])*
+            fn $fn_name($($arg_name: $arg_ty,)*) $(-> $ret_ty)?;
+        )*}
+
+        impl $name for $crate::r#priv::DefaultImpl {$(
+            $(#[$fn_attr])*
+            fn $fn_name($($arg_name: $arg_ty,)*) $(-> $ret_ty)? {
+                extern "Rust" {
+                    #[link_name = concat!("__", stringify!($name), "__", stringify!($fn_name))]
+                    fn $fn_name($($arg_name: $arg_ty,)*) $(-> $ret_ty)?;
+                }
+                unsafe { $fn_name($($arg_name,)*) }
+            }
+        )*}
+    };
+}
+
+/// Implement the interface for a struct.
+///
+/// This attribute should be added above the implementation of a trait for a
+/// struct, and the trait must be defined with [`def_interface!`].
+///
+/// It is not necessary to implement it in the same crate as the definition, but
+/// it is required that these crates are linked together.
+///
+/// See the [crate-level documentation](crate) for more details.
+#[macro_export]
+macro_rules! impl_interface {
+    (impl $interface:ident for $target:ident {$(
+        $(#[$fn_attr:meta])*
+        fn $fn_name:ident($($arg_name:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)? { $($body:tt)* }
+    )*}) => {
+        impl $interface for $target {$(
+            $(#[$fn_attr])*
+            fn $fn_name($($arg_name: $arg_ty,)*) $(-> $ret_ty)? {
+                #[export_name = concat!("__", stringify!($interface), "__", stringify!($fn_name))]
+                extern "Rust" fn $fn_name($($arg_name: $arg_ty,)*) $(-> $ret_ty)? {
+                    $($body)*
+                }
+                $fn_name($($arg_name,)*)
+            }
+        )*}
+    };
+}
+
+/// Call a function in the interface.
+///
+/// It is not necessary to call it in the same crate as the implementation, but
+/// it is required that these crates are linked together.
+///
+/// See the [crate-level documentation](crate) for more details.
+#[macro_export]
+macro_rules! call_interface {
+    ($($path:ident)::+ $(, $args:expr)* $(,)?) => {
+        ($crate::__interface_fn!([] $($path)::*))($($args,)*)
+    };
+    ($($path:ident)::+ ($($args:tt)*) $(,)?) => {
+        ($crate::__interface_fn!([] $($path)::*))($($args)*)
+    };
+    (::$($path:ident)::+ $(, $args:expr)* $(,)?) => {
+        ($crate::__interface_fn!([::] $($path)::*))($($args,)*)
+    };
+    (::$($path:ident)::+ ($($args:tt)*) $(,)?) => {
+        ($crate::__interface_fn!([::] $($path)::*))($($args)*)
+    };
+}
+
+/// Converts the given path to the default interface implementation.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __interface_fn {
+    ([$($path:tt)*] $interface:ident::$fn_name:ident) => {
+        <$crate::r#priv::DefaultImpl as $($path)*$interface>::$fn_name
+    };
+    ([$($path:tt)*] $head:ident::$($rest:tt)+) => {
+        $crate::__interface_fn!([$($path)* $head::] $($rest)*)
+    };
+}
+
+/// NON-PUBLIC APIs
+pub mod r#priv {
+    pub struct DefaultImpl;
+}

--- a/crate_interface_lite/src/lib.rs
+++ b/crate_interface_lite/src/lib.rs
@@ -37,8 +37,8 @@ macro_rules! def_interface {
 
 /// Implement the interface for a struct.
 ///
-/// This attribute should be use with a `impl` item of a trait for a struct, and
-/// the trait must be defined with [`def_interface!`].
+/// This attribute should be use with an `impl` item of a trait for a struct,
+/// and the trait must be defined with [`def_interface!`].
 ///
 /// It is not necessary to implement it in the same crate as the definition, but
 /// it is required that these crates are linked together.

--- a/crate_interface_lite/tests/test_crate_interface.rs
+++ b/crate_interface_lite/tests/test_crate_interface.rs
@@ -1,0 +1,38 @@
+use crate_interface_lite::*;
+
+def_interface!(
+    trait SimpleIf {
+        fn foo() -> u32;
+
+        /// Test comments
+        fn bar(a: u16, b: &[u8], c: &str);
+    }
+);
+
+pub struct SimpleIfImpl;
+impl_interface!(
+    impl SimpleIf for SimpleIfImpl {
+        fn foo() -> u32 {
+            456
+        }
+
+        /// Test comments2
+        fn bar(a: u16, b: &[u8], c: &str) {
+            println!("{} {:?} {}", a, b, c);
+            assert_eq!(b[1], 3);
+        }
+    }
+);
+
+mod private {
+    pub fn test_call_in_mod() {
+        crate::call_interface!(super::SimpleIf::bar, 123, &[2, 3, 5, 7, 11], "test");
+        crate::call_interface!(crate::SimpleIf::foo,);
+    }
+}
+
+#[test]
+fn test_crate_interface_call() {
+    assert_eq!(call_interface!(SimpleIf::foo), 456);
+    private::test_call_in_mod();
+}

--- a/crate_interface_lite/tests/test_crate_interface.rs
+++ b/crate_interface_lite/tests/test_crate_interface.rs
@@ -26,13 +26,14 @@ impl_interface!(
 
 mod private {
     pub fn test_call_in_mod() {
-        crate::call_interface!(super::SimpleIf::bar, 123, &[2, 3, 5, 7, 11], "test");
+        crate::call_interface!(super::SimpleIf::bar(123, &[2, 3, 5, 7, 11], "test"));
         crate::call_interface!(crate::SimpleIf::foo,);
     }
 }
 
 #[test]
 fn test_crate_interface_call() {
+    call_interface!(SimpleIf::bar, 123, &[2, 3, 5, 7, 11], "test");
     assert_eq!(call_interface!(SimpleIf::foo), 456);
     private::test_call_in_mod();
 }


### PR DESCRIPTION
This PR adds a lightweight version of crate_interface. 

## Motivation

The major reason for crate_interface_lite is the same as [pin-project-lite](https://crates.io/crates/pin-project-lite) -- using declarative macros does not require any external dependencies and could speed up the fresh builds (that is building from scratch with crate_interface requires compiling proc-macro related crates beforehand). Also, for potential library authors use this crate, crate_interface_lite would result in a tidier dependency tree of their projects.

## Implementation

Due to the limitations of declarative macros, the lite one lacks supports for complex ASTs. And I have documented perceptible differences[^1].

Furthermore, `crate_interface_lite::def_interface` uses a different approach to work with `call_interface`. Instead of generating a private `mod` to include linked `extern fn`s[^2], it implements the defined interface for a dummy struct, as illustrated below:

```rust
// With crate_interface_lite．．．
crate_interface_lite::def_interface!(
	trait SimpleIf {
	    fn foo() -> u32;
	}
);
impl SimpleIf for crate_interface_lite::DefaultImpl {
    fn foo() -> u32 {
        extern "Rust" {
            #[link_name = "__SimpleIf__foo"]
            fn foo() -> u32;
        }
        unsafe { foo() }
    }
}

// With crate_interface...
#[crate_interface::def_interface]
trait SimpleIf {
	fn foo() -> u32;
}
mod __SimpleIf_mod {
    use super::*;
    extern "Rust" {
        pub fn __SimpleIf_foo() -> u32;
    }
}
```

This should be transparent for users, since the implementation details are not exposed to them.

## Future works

If you accept this PR, I would like to take the responsibility for the future maintenance of crate_interface_lite :)

[^1]: Though some of them could be resolved, but it would complicate the internal macro parsing procedure.
[^2]: This is actually impossible for declarative macros unless [`concat_idents`](https://doc.rust-lang.org/std/macro.concat_idents.html) is stable.