### PR TITLE
Forbit using trait aliases to implement an interface

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,8 @@ pub fn def_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Implement the interface for a struct.
 ///
 /// This attribute should be added above the implementation of a trait for a
-/// struct, and the trait must be defined with [`#[def_interface]`](def_interface!).
+/// struct, and the trait must be defined with
+/// [`#[def_interface]`](macro@crate::def_interface).
 ///
 /// It is not necessary to implement it in the same crate as the definition, but
 /// it is required that these crates are linked together.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,9 @@ pub fn def_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
 
+    // Enforce no alias is used to implement an interface, as this makes it
+    // possible to link the function called by `call_interface` to an
+    // implementation with a different signature, which is extremely unsound.
     let alias_guard_name = format_ident!("__MustNotAnAlias__{}", trait_name);
     let alias_guard = parse_quote!(
         #[allow(non_upper_case_globals)]
@@ -111,7 +114,6 @@ pub fn def_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     fn foo() {}
 /// }
 /// ```
-///
 #[proc_macro_attribute]
 pub fn impl_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
     if !attr.is_empty() {


### PR DESCRIPTION
## Motivation

This PR prevents users from using trait aliases to implement an interface. Although they rarely do so, it is indeed possible to write unsound code as illustrated below:

```rust
#[crate_interface::def_interface]
trait MyIf1 {
    fn foo() -> usize;
}

#[crate_interface::def_interface]
trait MyIf2 {
    fn foo() -> isize;
    //          ^^^^^ Use a slightly different signature
    //                to make the assertion safely passes.
}

const _: () = {
    use MyIf2 as MyIf1; // Alias MyIf2 to MyIf1
    struct MyImpl;
    #[crate_interface::impl_interface]
    impl MyIf1 for MyImpl {
        fn foo() -> isize { -1234 }
        // ^^^ It corresponds to an `extern fn` named `__MyIf_foo`,
        //     which is exactly what `call_interface!(MyIf1::foo)` invokes,
        //     but its return type is not `usize`!
    }
};

assert_eq!(crate_interface::call_interface!(MyIf1::foo), (-1234isize) as usize);
```

## Implementation

 The approach is rather straightforward, as illustrated below:

```rust
// #[crate_interface::def_interface]
trait MyIf1 {
    fn foo() -> usize;
    const __MustNotAnAlias__MyIf1: () = ();
    //    ^^^^^^^^^^^^^^^^^^^^^^^ An dummy item is appended to the trait definition;
    //                            it has a default value, so it's invisible for users.
}

use MyIf1 as MyIf2;
struct MyImpl;
// #[crate_interface::impl_interface]
impl MyIf2 for MyImpl {
    fn foo() -> usize { 1234 }
    const __MustNotAnAlias__MyIf2: () = ();
    //                      ^^^^^ This item does not exist in MyIf1,
    //                            resulting in a compile error.
}
