### PR TITLE
Add `gen_caller` and `namespace = <ns>` options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/arceos-org/crate_interface"
 documentation = "https://docs.rs/crate_interface"
 keywords = ["arceos", "api", "macro"]
 categories = ["development-tools::procedural-macro-helpers", "no-std"]
-rust-version = "1.57"
+rust-version = "1.60"
 
 [dependencies]
 proc-macro2 = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/arceos-org/crate_interface"
 documentation = "https://docs.rs/crate_interface"
 keywords = ["arceos", "api", "macro"]
 categories = ["development-tools::procedural-macro-helpers", "no-std"]
-rust-version = "1.60"
+rust-version = "1.68"
 
 [dependencies]
 proc-macro2 = "1.0"

--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@
 [![Docs.rs](https://docs.rs/crate_interface/badge.svg)](https://docs.rs/crate_interface)
 [![CI](https://github.com/arceos-org/crate_interface/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/arceos-org/crate_interface/actions/workflows/ci.yml)
 
-Provides a way to **define** an interface (trait) in a crate, but can
-**implement** or **use** it in any crate. It 's usually used to solve
-the problem of *circular dependencies* between crates.
+Provides a way to **define** a static interface (as a Rust trait) in a crate,
+**implement** it in another crate, and **call** it from any crate, using
+procedural macros. This is useful when you want to solve *circular dependencies*
+between crates.
 
 ## Example
+
+### Basic Usage
+
+Define an interface using the `def_interface!` attribute macro, implement it
+using the `impl_interface!` attribute macro, and call it using the
+`call_interface!` macro. These macros can be used in separate crates.
 
 ```rust
 // Define the interface
@@ -38,6 +45,109 @@ assert_eq!(
     "Hello, rust 456!"
 );
 ```
+
+### Generating Calling Helper Functions
+
+It's also possible to generate calling helper functions for each interface
+function, so that you can call them directly without using the `call_interface!`
+macro.
+
+```rust
+// Define the interface with caller generation
+#[crate_interface::def_interface(gen_caller)]
+pub trait HelloIf {
+    fn hello(&self, name: &str, id: usize) -> String;
+}
+
+// a function to call the interface function is generated here like:
+// fn hello(name: &str, id: usize) -> String { ... }
+
+// Implement the interface in any crate
+struct HelloIfImpl;
+
+#[crate_interface::impl_interface]
+impl HelloIf for HelloIfImpl {
+    fn hello(&self, name: &str, id: usize) -> String {
+        format!("Hello, {} {}!", name, id)
+    }
+}
+
+// Call the generated caller function using caller function
+assert_eq!(
+    unsafe { hello("world", 123) },
+    "Hello, world 123!"
+);
+```
+
+### Avoiding Name Conflicts with Namespaces
+
+You can specify a namespace for the interface to avoid name conflicts when
+multiple interfaces with the same name are defined in different crates. It's
+done by adding the `namespace` argument to the `def_interface!`,
+`impl_interface!` and `call_interface!` macros.
+
+```rust
+mod a {
+    #[crate_interface::def_interface(namespace = ShoppingMall)]
+    pub trait HelloIf {
+        fn hello(&self, name: &str, id: usize) -> String;
+    }
+}
+
+mod b {
+    #[crate_interface::def_interface(namespace = Restaurant)]
+    pub trait HelloIf {
+        fn hello(&self, name: &str, id: usize) -> String;
+    }
+}
+
+mod c {
+    use super::{a, b};
+
+    struct HelloIfImplA;
+
+    #[crate_interface::impl_interface(namespace = ShoppingMall)]
+    impl a::HelloIf for HelloIfImplA {
+        fn hello(&self, name: &str, id: usize) -> String {
+            format!("Welcome to the mall, {} {}!", name, id)
+        }
+    }
+
+    struct HelloIfImplB;
+    #[crate_interface::impl_interface(namespace = Restaurant)]
+    impl b::HelloIf for HelloIfImplB {
+        fn hello(&self, name: &str, id: usize) -> String {
+            format!("Welcome to the restaurant, {} {}!", name, id)
+        }
+    }
+}
+
+fn main() {
+    // Call the interface functions using namespaces
+    assert_eq!(
+        crate_interface::call_interface!(namespace = ShoppingMall, a::HelloIf::hello("Alice", 1)),
+        "Welcome to the mall, Alice 1!"
+    );
+    assert_eq!(
+        crate_interface::call_interface!(namespace = Restaurant, b::HelloIf::hello("Bob", 2)),
+        "Welcome to the restaurant, Bob 2!"
+    );
+}
+
+```
+
+## Things to Note
+
+A few things to keep in mind when using this crate:
+
+- Do not implement an interface for multiple types. No matter in the same crate
+  or different crates as long as they are linked together, it will cause a
+  link-time error due to duplicate symbol definitions.
+- Do not define multiple interfaces with the same name, without assigning them
+  different namespaces. `crate_interface` does not use crates and modules to
+  isolate interfaces, only their names and namespaces are used to identify them.
+- Do not aliasing interface traits with `use path::to::Trait as Alias;`, only
+  use the original trait name, or an error will be raised.
 
 ## Implementation
 
@@ -82,4 +192,43 @@ assert_eq!(
     unsafe { __HelloIf_mod::__HelloIf_hello("world", 123) },
     "Hello, world 123!"
 );
+```
+
+If you enable the `gen_caller` option in `def_interface`, calling helper
+functions will also be generated. For example, `HelloIf` above will generate:
+
+```rust
+pub trait HelloIf {
+    fn hello(&self, name: &str, id: usize) -> String;
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+pub mod __HelloIf_mod {
+    use super::*;
+    extern "Rust" {
+        pub fn __HelloIf_hello(name: &str, id: usize) -> String;
+    }
+}
+#[inline]
+pub fn hello(name: &str, id: usize) -> String {
+    unsafe { __HelloIf_mod::__HelloIf_hello(name, id) }
+}
+```
+
+Namespaces are implemented by further mangling the symbol names with the
+namespace, for example, if `HelloIf` is defined with the `ShoppingMall`
+namespace, the generated code will be:
+
+```rust
+pub trait HelloIf {
+    fn hello(&self, name: &str, id: usize) -> String;
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+pub mod __HelloIf_mod {
+    use super::*;
+    extern "Rust" {
+        pub fn __ShoppingMall_HelloIf_hello(name: &str, id: usize) -> String;
+    }
+}
 ```

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ impl HelloIf for HelloIfImpl {
 
 // Call the generated caller function using caller function
 assert_eq!(
-    unsafe { hello("world", 123) },
+    hello("world", 123),
     "Hello, world 123!"
 );
 ```
@@ -149,8 +149,8 @@ A few things to keep in mind when using this crate:
 - Do not define multiple interfaces with the same name, without assigning them
   different namespaces. `crate_interface` does not use crates and modules to
   isolate interfaces, only their names and namespaces are used to identify them.
-- Do not aliasing interface traits with `use path::to::Trait as Alias;`, only
-  use the original trait name, or an error will be raised.
+- Do not alias interface traits with `use path::to::Trait as Alias;`, only use
+  the original trait name, or an error will be raised.
 
 ## Implementation
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ It's also possible to generate calling helper functions for each interface
 function, so that you can call them directly without using the `call_interface!`
 macro.
 
+This is the **RECOMMENDED** way to use this crate whenever possible, as it
+provides a much more ergonomic API.
+
 ```rust
 // Define the interface with caller generation
 #[crate_interface::def_interface(gen_caller)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,152 @@
+//! Arguments definition and parsing for the `def_interface`, `impl_interface`
+//! attributes and the `call_interface!` macro.
+
+use syn::{
+    parenthesized,
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
+    Error, Expr, Ident, Path, Result, Token,
+};
+
+fn duplicate_arg_error(ident: &Ident) -> Error {
+    Error::new_spanned(ident, format!("duplicate argument: {}", ident.to_string()))
+}
+
+fn unknown_arg_error(ident: &Ident) -> Error {
+    Error::new_spanned(ident, format!("unknown argument: {}", ident.to_string()))
+}
+
+const KEY_GEN_CALLER: &str = "gen_caller";
+const KEY_NAMESPACE: &str = "namespace";
+
+/// Arguments for the `def_interface` attribute.
+#[derive(Debug, Default)]
+pub struct DefInterfaceArgs {
+    /// Generate caller functions for members of the interface.
+    pub gen_caller: bool,
+    /// Namespace for the interface. Used to avoid name collisions and must
+    /// match the one in `impl_interface`.
+    pub namespace: Option<String>,
+}
+
+impl Parse for DefInterfaceArgs {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut arg = DefInterfaceArgs::default();
+
+        while !input.is_empty() {
+            let ident: Ident = input.parse()?;
+
+            match ident.to_string().as_str() {
+                KEY_GEN_CALLER => {
+                    if arg.gen_caller {
+                        return Err(duplicate_arg_error(&ident));
+                    }
+
+                    arg.gen_caller = true;
+                }
+                KEY_NAMESPACE => {
+                    if arg.namespace.is_some() {
+                        return Err(duplicate_arg_error(&ident));
+                    }
+
+                    input.parse::<Token![=]>()?;
+                    let ns_ident: Ident = input.parse()?;
+                    arg.namespace = Some(ns_ident.to_string());
+                }
+                _ => {
+                    return Err(unknown_arg_error(&ident));
+                }
+            }
+
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            }
+        }
+
+        Ok(arg)
+    }
+}
+
+/// Arguments for the `impl_interface` attribute.
+#[derive(Debug, Default)]
+pub struct ImplInterfaceArgs {
+    /// Namespace for the interface. Used to avoid name collisions and must
+    /// match the one in `def_interface`.
+    pub namespace: Option<String>,
+}
+
+impl Parse for ImplInterfaceArgs {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut arg = ImplInterfaceArgs::default();
+
+        while !input.is_empty() {
+            let ident: Ident = input.parse()?;
+
+            match ident.to_string().as_str() {
+                KEY_NAMESPACE => {
+                    if arg.namespace.is_some() {
+                        return Err(duplicate_arg_error(&ident));
+                    }
+
+                    input.parse::<Token![=]>()?;
+                    let ns_ident: Ident = input.parse()?;
+                    arg.namespace = Some(ns_ident.to_string());
+                }
+                _ => {
+                    return Err(unknown_arg_error(&ident));
+                }
+            }
+
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            }
+        }
+
+        Ok(arg)
+    }
+}
+
+/// Arguments for the `call_interface!` macro.
+pub struct CallInterface {
+    /// Optional namespace for the interface.
+    pub namespace: Option<String>,
+    /// Path to the interface method to call.
+    pub path: Path,
+    /// Arguments to pass to the interface method.
+    pub args: Punctuated<Expr, Token![,]>,
+}
+
+impl Parse for CallInterface {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut namespace = None;
+        let content;
+
+        let mut path: Path = input.parse()?;
+        // try to parse namespace if any, we just assume that no programmer with
+        // basic sanity would name a trait "namespace", and, anyway, a valid
+        // path here requires at least 2 segments (Trait::func).
+        if path.get_ident().is_some_and(|i| i == KEY_NAMESPACE) {
+            input.parse::<Token![=]>()?;
+            let ns_ident: Ident = input.parse()?;
+            namespace = Some(ns_ident.to_string());
+
+            input.parse::<Token![,]>()?;
+            path = input.parse()?;
+        }
+
+        let args = if input.peek(Token![,]) {
+            input.parse::<Token![,]>()?;
+            input.parse_terminated(Expr::parse, Token![,])?
+        } else if !input.is_empty() {
+            parenthesized!(content in input);
+            content.parse_terminated(Expr::parse, Token![,])?
+        } else {
+            Punctuated::new()
+        };
+        Ok(CallInterface {
+            namespace,
+            path,
+            args,
+        })
+    }
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -9,11 +9,11 @@ use syn::{
 };
 
 fn duplicate_arg_error(ident: &Ident) -> Error {
-    Error::new_spanned(ident, format!("duplicate argument: {}", ident.to_string()))
+    Error::new_spanned(ident, format!("duplicate argument: {}", ident))
 }
 
 fn unknown_arg_error(ident: &Ident) -> Error {
-    Error::new_spanned(ident, format!("unknown argument: {}", ident.to_string()))
+    Error::new_spanned(ident, format!("unknown argument: {}", ident))
 }
 
 const KEY_GEN_CALLER: &str = "gen_caller";
@@ -125,13 +125,15 @@ impl Parse for CallInterface {
         // try to parse namespace if any, we just assume that no programmer with
         // basic sanity would name a trait "namespace", and, anyway, a valid
         // path here requires at least 2 segments (Trait::func).
-        if path.get_ident().is_some_and(|i| i == KEY_NAMESPACE) {
-            input.parse::<Token![=]>()?;
-            let ns_ident: Ident = input.parse()?;
-            namespace = Some(ns_ident.to_string());
+        if let Some(ident) = path.get_ident() {
+            if ident == KEY_NAMESPACE {
+                input.parse::<Token![=]>()?;
+                let ns_ident: Ident = input.parse()?;
+                namespace = Some(ns_ident.to_string());
 
-            input.parse::<Token![,]>()?;
-            path = input.parse()?;
+                input.parse::<Token![,]>()?;
+                path = input.parse()?;
+            }
         }
 
         let args = if input.peek(Token![,]) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ fn extern_fn_mod_name(trait_name: &Ident) -> Ident {
 ///
 /// It is not necessary to define it in the same crate as the implementation,
 /// but it is required that these crates are linked together.
-/// 
+///
 /// It is also possible to generate calling helper functions for each interface
 /// function by enabling the `gen_caller` option.
 ///
@@ -175,7 +175,7 @@ pub fn def_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// It is not necessary to implement it in the same crate as the definition, but
 /// it is required that these crates are linked together.
-/// 
+///
 /// The specified trait name must not be an alias to the originally defined
 /// name; otherwise, it will result in a compile error.
 ///
@@ -193,19 +193,19 @@ pub fn def_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     fn foo() {}
 /// }
 /// ```
-/// 
+///
 /// It's also mandatory to match the namespace if one is specified when defining
 /// the interface. For example, the following will result in a compile error:
-/// 
+///
 /// ```rust,compile_fail
 /// # use crate_interface::*;
 /// #[def_interface(namespace = MyNs)]
 /// trait MyIf {
 ///     fn foo();
 /// }
-/// 
+///
 /// struct MyImpl;
-/// 
+///
 /// #[impl_interface(namespace = OtherNs)] // error: namespace does not match
 /// impl MyIf for MyImpl {
 ///     fn foo() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,13 +49,17 @@ fn extern_fn_mod_name(trait_name: &Ident) -> Ident {
     format_ident!("__{}_mod", trait_name)
 }
 
-/// Define an interface.
+/// Define an crate interface.
 ///
 /// This attribute should be added above the definition of a trait. All traits
-/// that use the attribute cannot have the same name.
+/// that use the attribute cannot have the same name, unless they are assigned
+/// different namespaces with `namespace = "..."` option.
 ///
 /// It is not necessary to define it in the same crate as the implementation,
 /// but it is required that these crates are linked together.
+/// 
+/// It is also possible to generate calling helper functions for each interface
+/// function by enabling the `gen_caller` option.
 ///
 /// See the [crate-level documentation](crate) for more details.
 #[proc_macro_attribute]
@@ -171,11 +175,7 @@ pub fn def_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// It is not necessary to implement it in the same crate as the definition, but
 /// it is required that these crates are linked together.
-///
-/// See the [crate-level documentation](crate) for more details.
-///
-/// # Caveat
-///
+/// 
 /// The specified trait name must not be an alias to the originally defined
 /// name; otherwise, it will result in a compile error.
 ///
@@ -193,6 +193,26 @@ pub fn def_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     fn foo() {}
 /// }
 /// ```
+/// 
+/// It's also mandatory to match the namespace if one is specified when defining
+/// the interface. For example, the following will result in a compile error:
+/// 
+/// ```rust,compile_fail
+/// # use crate_interface::*;
+/// #[def_interface(namespace = MyNs)]
+/// trait MyIf {
+///     fn foo();
+/// }
+/// 
+/// struct MyImpl;
+/// 
+/// #[impl_interface(namespace = OtherNs)] // error: namespace does not match
+/// impl MyIf for MyImpl {
+///     fn foo() {}
+/// }
+/// ```
+///
+/// See the [crate-level documentation](crate) for more details.
 #[proc_macro_attribute]
 pub fn impl_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
     let arg = syn::parse_macro_input!(attr as ImplInterfaceArgs);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ pub fn def_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
     // should be provided to ensure that `impl_interface` have a namespace
     // specified when `def_interface` has one.
     if let Some(ns) = &macro_arg.namespace {
-        let ns_guard_name = namespace_guard_name(&ns);
+        let ns_guard_name = namespace_guard_name(ns);
         let ns_guard = parse_quote!(
             #[allow(non_upper_case_globals)]
             #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 #![doc = include_str!("../README.md")]
 
-use std::vec;
-
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::{format_ident, quote};
@@ -49,7 +47,7 @@ fn extern_fn_mod_name(trait_name: &Ident) -> Ident {
     format_ident!("__{}_mod", trait_name)
 }
 
-/// Define an crate interface.
+/// Define a crate interface.
 ///
 /// This attribute should be added above the definition of a trait. All traits
 /// that use the attribute cannot have the same name, unless they are assigned
@@ -138,7 +136,7 @@ pub fn def_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
     ast.items.push(alias_guard);
 
     // Enforce namespace matching if a namespace is specified. No default value
-    // should be provided to ensure that `impl_interface` have a namespace
+    // should be provided to ensure that `impl_interface` has a namespace
     // specified when `def_interface` has one.
     if let Some(ns) = &macro_arg.namespace {
         let ns_guard_name = namespace_guard_name(ns);
@@ -167,7 +165,7 @@ pub fn def_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
     .into()
 }
 
-/// Implement the interface for a struct.
+/// Implement the crate interface for a struct.
 ///
 /// This attribute should be added above the implementation of a trait for a
 /// struct, and the trait must be defined with
@@ -298,7 +296,7 @@ pub fn impl_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
     quote! { #ast }.into()
 }
 
-/// Call a function in the interface.
+/// Call a function in a crate interface.
 ///
 /// It is not necessary to call it in the same crate as the implementation, but
 /// it is required that these crates are linked together.

--- a/tests/test_crate_interface.rs
+++ b/tests/test_crate_interface.rs
@@ -26,6 +26,51 @@ impl SimpleIf for SimpleIfImpl {
     }
 }
 
+#[def_interface(gen_caller)]
+trait WithCallerIf {
+    fn baz(&self, x: i32) -> i32;
+}
+
+struct WithCallerIfImpl;
+
+#[impl_interface]
+impl WithCallerIf for WithCallerIfImpl {
+    fn baz(&self, x: i32) -> i32 {
+        x + 1
+    }
+}
+
+mod a {
+    #[crate_interface::def_interface(gen_caller, namespace = A_NS)]
+    pub trait NamespaceIf {
+        fn qux() -> i32;
+    }
+}
+
+mod b {
+    #[crate_interface::def_interface(gen_caller, namespace = B_NS)]
+    pub trait NamespaceIf {
+        fn qux() -> i32;
+    }
+}
+
+struct NamespaceIfImplA;
+struct NamespaceIfImplB;
+
+#[crate_interface::impl_interface(namespace = A_NS)]
+impl a::NamespaceIf for NamespaceIfImplA {
+    fn qux() -> i32 {
+        1
+    }
+}
+
+#[crate_interface::impl_interface(namespace = B_NS)]
+impl b::NamespaceIf for NamespaceIfImplB {
+    fn qux() -> i32 {
+        2
+    }
+}
+
 mod private {
     pub fn test_call_in_mod() {
         crate::call_interface!(super::SimpleIf::bar(123, &[2, 3, 5, 7, 11], "test"));
@@ -38,4 +83,18 @@ fn test_crate_interface_call() {
     call_interface!(SimpleIf::bar, 123, &[2, 3, 5, 7, 11], "test");
     assert_eq!(call_interface!(SimpleIf::foo), 456);
     private::test_call_in_mod();
+}
+
+#[test]
+fn test_calling_helper_function() {
+    assert_eq!(baz(42), 43);
+}
+
+#[test]
+fn test_namespace_interface() {
+    assert_eq!(call_interface!(namespace = A_NS, a::NamespaceIf::qux), 1);
+    assert_eq!(call_interface!(namespace = B_NS, b::NamespaceIf::qux), 2);
+
+    assert_eq!(a::qux(), 1);
+    assert_eq!(b::qux(), 2);
 }


### PR DESCRIPTION
Two options are introduced in this PR:

- `gen_caller`, used in `def_interface` only, to generate calling helper function alongside the marked trait.
- `namespace = <ns>`, used in `def_interface(namespace = <ns>)`/`impl_interface(namespace = <ns>)`/`call_interface!(namespace = <ns>, <trait_path>, ...)`.

For more ergonomic usage.