### PR TITLE
Use weak symbols to allow using default trait methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,23 @@ jobs:
       run: cargo clippy --workspace --target ${{ matrix.targets }} --all-features
     - name: Build
       run: cargo build --workspace --target ${{ matrix.targets }} --all-features
-    - name: Unit test
-      if: ${{ matrix.targets == 'x86_64-unknown-linux-gnu' && matrix.rust-toolchain != '${{ needs.metadata.outputs.rust_version }}' }}
+    - name: Unit test (without weak_default)
+      if: ${{ matrix.targets == 'x86_64-unknown-linux-gnu' }}
       run: cargo test --workspace --target ${{ matrix.targets }} -- --nocapture
-    - name: Multi-crate test
-      if: ${{ matrix.targets == 'x86_64-unknown-linux-gnu' && matrix.rust-toolchain != '${{ needs.metadata.outputs.rust_version }}' }}
-      run: cargo test --workspace --target ${{ matrix.targets }} -- --nocapture
+    - name: Unit test (with weak_default)
+      if: ${{ matrix.targets == 'x86_64-unknown-linux-gnu' && matrix.rust-toolchain == 'nightly' }}
+      run: cargo test --workspace --target ${{ matrix.targets }} --features weak_default -- --nocapture
+    - name: Multi-crate test (without weak_default)
+      if: ${{ matrix.targets == 'x86_64-unknown-linux-gnu' }}
+      working-directory: test_crates
+      run: cargo run -p test-simple
+    - name: Multi-crate test (with weak_default, nightly only)
+      if: ${{ matrix.targets == 'x86_64-unknown-linux-gnu' && matrix.rust-toolchain == 'nightly' }}
+      working-directory: test_crates
+      run: |
+        cargo run -p test-simple
+        cargo run -p test-weak
+        cargo run -p test-weak-partial
 
   doc:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
     - name: Unit test
       if: ${{ matrix.targets == 'x86_64-unknown-linux-gnu' && matrix.rust-toolchain != '${{ needs.metadata.outputs.rust_version }}' }}
       run: cargo test --workspace --target ${{ matrix.targets }} -- --nocapture
+    - name: Multi-crate test
+      if: ${{ matrix.targets == 'x86_64-unknown-linux-gnu' && matrix.rust-toolchain != '${{ needs.metadata.outputs.rust_version }}' }}
+      run: cargo test --workspace --target ${{ matrix.targets }} -- --nocapture
 
   doc:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+**/target
 /.vscode
 .DS_Store
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["crate_interface_lite"]
+exclude = ["test_crates"]
 
 [package]
 name = "crate_interface"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.68"
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "2.0", features = ["full"] }
+syn = { version = "2.0", features = ["full", "visit-mut"] }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,11 @@ proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
 
+[features]
+default = []
+# Generate weak symbol functions for trait methods with default implementations.
+# Requires nightly Rust and `#![feature(linkage)]` in the crate that uses this.
+weak_default = []
+
 [lib]
 proc-macro = true

--- a/README.md
+++ b/README.md
@@ -139,6 +139,25 @@ fn main() {
 
 ```
 
+### Default Implementations with Weak Symbols
+
+The `weak_default` feature allows you to define **default implementations** for
+interface methods. These defaults are compiled as **weak symbols**, which means:
+
+- Implementors can choose to override only the methods they need
+- Methods without explicit implementations will automatically use the defaults
+- The linker resolves which implementation to use at link time
+
+This is useful when you want to provide sensible defaults while still allowing
+customization. To use this feature, you need to use nightly Rust and enable
+`#![feature(linkage)]` in the crate that defines the interface trait.
+
+Due to the limitation of the Rust compiler, it's impossible to implement an
+interface with default implementations in the same crate where it's defined. It
+should not be a problem for most cases, because the only sensible scenario an
+interface being implemented in the same crate where it's defined is when it's
+tested, and such tests can always be done in a separate crate.
+
 ## Things to Note
 
 A few things to keep in mind when using this crate:

--- a/src/def_interface.rs
+++ b/src/def_interface.rs
@@ -6,7 +6,10 @@ use quote::format_ident;
 use quote::quote;
 use syn::{parse_quote, Error, ItemTrait, TraitItem};
 #[cfg(feature = "weak_default")]
-use syn::{visit_mut::VisitMut, Block, Expr, ExprPath, Ident, Path, PathSegment, Signature, punctuated::Punctuated};
+use syn::{
+    punctuated::Punctuated, visit_mut::VisitMut, Block, Expr, ExprPath, Ident, Path, PathSegment,
+    Signature,
+};
 
 #[cfg(feature = "weak_default")]
 use std::collections::HashMap;

--- a/src/def_interface.rs
+++ b/src/def_interface.rs
@@ -4,10 +4,11 @@ use proc_macro2::TokenStream;
 #[cfg(feature = "weak_default")]
 use quote::format_ident;
 use quote::quote;
-use syn::{parse_quote, Error, ItemTrait, Signature, TraitItem};
+use syn::{parse_quote, Error, ItemTrait, TraitItem};
 #[cfg(feature = "weak_default")]
-use syn::{visit_mut::VisitMut, Block, Expr, ExprPath, Ident, Path, PathSegment, punctuated::Punctuated};
+use syn::{visit_mut::VisitMut, Block, Expr, ExprPath, Ident, Path, PathSegment, Signature, punctuated::Punctuated};
 
+#[cfg(feature = "weak_default")]
 use std::collections::HashMap;
 
 use crate::args::DefInterfaceArgs;

--- a/src/def_interface.rs
+++ b/src/def_interface.rs
@@ -227,7 +227,6 @@ pub fn def_interface(
                     #[no_mangle]
                     extern "Rust" #extern_fn_sig #default_body_cleaned
                 };
-                // weak_default_fns.push(weak_default_impl);
 
                 let caller_args = extract_caller_args(sig)?;
                 *default_body = syn::parse2(quote! {{

--- a/src/def_interface.rs
+++ b/src/def_interface.rs
@@ -1,8 +1,14 @@
 //! The implementation of the [`crate::def_interface`] attribute macro.
 
 use proc_macro2::TokenStream;
+#[cfg(feature = "weak_default")]
+use quote::format_ident;
 use quote::quote;
-use syn::{parse_quote, Error, ItemTrait, TraitItem};
+use syn::{parse_quote, Error, ItemTrait, Signature, TraitItem};
+#[cfg(feature = "weak_default")]
+use syn::{visit_mut::VisitMut, Block, Expr, ExprPath, Ident, Path, PathSegment, punctuated::Punctuated};
+
+use std::collections::HashMap;
 
 use crate::args::DefInterfaceArgs;
 use crate::errors::generic_not_allowed_error;
@@ -12,6 +18,143 @@ use crate::naming::{
     alias_guard_name, extern_fn_mod_name, extern_fn_name, extract_caller_args, namespace_guard_name,
 };
 use crate::validator::validate_fn_signature;
+
+/// Rewrite all references to `Self::some_method` in the default body.
+///
+/// Both direct calls (`Self::method(...)`) and indirect references (`Self::method` as value)
+/// are handled uniformly by generating proxy functions. This simplifies the implementation
+/// and ensures consistent behavior.
+///
+/// This is necessary because default implementations may reference other trait methods
+/// using `Self::method_name` syntax. We need to rewrite these references to use the
+/// extern function names so that they resolve to the correct (possibly overridden)
+/// implementation at link time.
+#[cfg(feature = "weak_default")]
+fn rewrite_self_in_default_body(
+    default_body: &Block,
+    trait_name: &Ident,
+    namespace: Option<&str>,
+    method_signatures: &HashMap<String, Signature>,
+) -> TokenStream {
+    /// Visitor that rewrites `Self::method_name` references using proxy functions.
+    struct SelfRefRewriter<'a> {
+        trait_name: &'a Ident,
+        namespace: Option<&'a str>,
+        method_signatures: &'a HashMap<String, Signature>,
+        /// Generated proxy functions (method_name -> proxy_fn_code)
+        /// Each method only generates one proxy function
+        generated_proxies: HashMap<String, TokenStream>,
+    }
+
+    impl SelfRefRewriter<'_> {
+        /// Check if an expression is a `Self::method_name` path (two segments starting with "Self")
+        fn is_self_method_path(expr: &Expr) -> Option<Ident> {
+            if let Expr::Path(path_expr) = expr {
+                let path = &path_expr.path;
+                if path.segments.len() == 2 {
+                    let first_seg = &path.segments[0];
+                    let second_seg = &path.segments[1];
+                    if first_seg.ident == "Self" {
+                        return Some(second_seg.ident.clone());
+                    }
+                }
+            }
+            None
+        }
+
+        /// Get the proxy function name for a method
+        fn proxy_name(method_name: &Ident) -> Ident {
+            format_ident!("__self_proxy_{}", method_name)
+        }
+
+        /// Ensure a proxy function exists for the method, generating it if needed
+        fn ensure_proxy_fn(&mut self, method_name: Ident) -> Option<Ident> {
+            let method_key = method_name.to_string();
+
+            // Return early if already generated
+            if self.generated_proxies.contains_key(&method_key) {
+                return Some(Self::proxy_name(&method_name));
+            }
+
+            // Generate new proxy function
+            let sig = self.method_signatures.get(&method_key)?;
+            let mod_name = extern_fn_mod_name(self.trait_name);
+            let extern_fn = extern_fn_name(self.namespace, &self.trait_name, &method_name);
+            let proxy_name = Self::proxy_name(&method_name);
+
+            // Extract arguments for the call
+            let caller_args = extract_caller_args(sig).ok()?;
+
+            // Clone signature and rename
+            let mut proxy_sig = sig.clone();
+            proxy_sig.ident = proxy_name.clone();
+
+            // Generate the proxy function
+            let proxy_fn = quote! {
+                #[allow(non_snake_case)]
+                #proxy_sig {
+                    unsafe { #mod_name :: #extern_fn ( #caller_args ) }
+                }
+            };
+
+            self.generated_proxies.insert(method_key, proxy_fn);
+            Some(proxy_name)
+        }
+
+        /// Replace a `Self::method` expression with a proxy function reference
+        fn replace_with_proxy(&mut self, expr: &mut Expr, method_name: Ident) {
+            if let Some(proxy_name) = self.ensure_proxy_fn(method_name) {
+                *expr = Expr::Path(ExprPath {
+                    attrs: vec![],
+                    qself: None,
+                    path: Path {
+                        leading_colon: None,
+                        segments: {
+                            let mut segs = Punctuated::new();
+                            segs.push(PathSegment::from(proxy_name));
+                            segs
+                        },
+                    },
+                });
+            }
+        }
+    }
+
+    impl VisitMut for SelfRefRewriter<'_> {
+        fn visit_expr_mut(&mut self, expr: &mut Expr) {
+            // First, recursively visit child expressions
+            syn::visit_mut::visit_expr_mut(self, expr);
+
+            // Handle any `Self::method` reference (both direct calls and value references)
+            if let Some(method_name) = Self::is_self_method_path(expr) {
+                self.replace_with_proxy(expr, method_name);
+            }
+        }
+    }
+
+    let mut body = default_body.clone();
+    let mut rewriter = SelfRefRewriter {
+        trait_name,
+        namespace,
+        method_signatures,
+        generated_proxies: HashMap::new(),
+    };
+    rewriter.visit_block_mut(&mut body);
+
+    // Insert proxy functions at the beginning of the block
+    let proxy_fns: Vec<_> = rewriter.generated_proxies.into_values().collect();
+    if proxy_fns.is_empty() {
+        quote! { #body }
+    } else {
+        let stmts = &body.stmts;
+        quote! {
+            {
+                #(#proxy_fns)*
+                #(#stmts)*
+            }
+        }
+    }
+}
 
 /// The implementation of the [`crate::def_interface`] attribute macro.
 pub fn def_interface(
@@ -27,8 +170,19 @@ pub fn def_interface(
 
     let mod_name = extern_fn_mod_name(trait_name);
 
+    // Collect all method signatures for use in rewriting Self::method references
+    #[cfg(feature = "weak_default")]
+    let mut method_signatures: HashMap<String, Signature> = HashMap::new();
+    #[cfg(feature = "weak_default")]
+    for item in &ast.items {
+        if let TraitItem::Fn(method) = item {
+            let sig = &method.sig;
+            method_signatures.insert(sig.ident.to_string(), sig.clone());
+        }
+    }
+
     let mut extern_fn_list = vec![];
-    let mut callers: Vec<proc_macro2::TokenStream> = vec![];
+    let mut callers: Vec<TokenStream> = vec![];
 
     for item in &mut ast.items {
         if let TraitItem::Fn(method) = item {
@@ -57,19 +211,25 @@ pub fn def_interface(
             // Generate weak symbol function for methods with default implementations
             #[cfg(feature = "weak_default")]
             if let Some(default_body) = &mut method.default {
+                let default_body_cleaned = rewrite_self_in_default_body(
+                    default_body,
+                    trait_name,
+                    macro_arg.namespace.as_deref(),
+                    &method_signatures,
+                );
                 let weak_default_impl = quote! {
                     #[allow(non_snake_case)]
                     #[linkage = "weak"]
                     #[no_mangle]
-                    extern "Rust" #extern_fn_sig #default_body
+                    extern "Rust" #extern_fn_sig #default_body_cleaned
                 };
                 // weak_default_fns.push(weak_default_impl);
 
                 let caller_args = extract_caller_args(sig)?;
                 *default_body = syn::parse2(quote! {{
                     #weak_default_impl
-                    
-                    #extern_fn_name ( #caller_args ) 
+
+                    #extern_fn_name ( #caller_args )
                 }})?;
             }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,6 @@
 //! Error definitions for the crate interface.
 
-use syn::{Error, Generics, Ident};
+use syn::{Error, Generics, Ident, TraitItemFn};
 
 pub fn duplicate_arg_error(ident: &Ident) -> Error {
     Error::new_spanned(ident, format!("duplicate argument: {}", ident))
@@ -14,5 +14,17 @@ pub fn generic_not_allowed_error(generic: &Generics) -> Error {
     Error::new_spanned(
         generic,
         "generic parameters are not allowed in crate_interface",
+    )
+}
+
+#[cfg_attr(feature = "weak_default", allow(dead_code))]
+pub fn weak_default_required_error(method: &TraitItemFn) -> Error {
+    let fn_name = &method.sig.ident;
+    Error::new_spanned(
+        method,
+        format!(
+            r#"default implementation of method `{}` will not work as expected and therefore is not allowed without the `weak_default` feature. To use it, you need to enable the `weak_default` feature and use the nightly Rust toolchain, with `#![feature(linkage)]` at the top of your crate root."#,
+            fn_name
+        ),
     )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![allow(clippy::needless_doctest_main)]
 
 use proc_macro::TokenStream;
 use proc_macro2::Span;

--- a/test_crates/Cargo.toml
+++ b/test_crates/Cargo.toml
@@ -1,0 +1,25 @@
+[workspace]
+resolver = "2"
+members = [
+    "define-simple-traits",
+    "define-weak-traits",
+    "impl-simple-traits",
+    "impl-weak-traits",
+    "impl-weak-partial",
+    "test-simple",
+    "test-weak",
+    "test-weak-partial",
+]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[workspace.dependencies]
+crate_interface = { path = ".." }
+define-simple-traits = { path = "./define-simple-traits" }
+define-weak-traits = { path = "./define-weak-traits" }
+impl-simple-traits = { path = "./impl-simple-traits" }
+impl-weak-traits = { path = "./impl-weak-traits" }
+impl-weak-partial = { path = "./impl-weak-partial" }

--- a/test_crates/define-simple-traits/Cargo.toml
+++ b/test_crates/define-simple-traits/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "define-simple-traits"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+crate_interface.workspace = true

--- a/test_crates/define-simple-traits/src/lib.rs
+++ b/test_crates/define-simple-traits/src/lib.rs
@@ -1,0 +1,43 @@
+//! Define simple traits without default implementations.
+//!
+//! This crate defines several traits using `#[def_interface]` that do NOT have
+//! any default implementations. These traits must be fully implemented.
+
+use crate_interface::def_interface;
+
+/// A simple interface with basic methods.
+#[def_interface]
+pub trait SimpleIf {
+    /// A simple function that returns a u32.
+    fn get_value() -> u32;
+
+    /// A function that takes arguments.
+    fn compute(a: u32, b: u32) -> u32;
+
+    /// A function that returns a string slice.
+    fn get_name() -> &'static str;
+}
+
+/// An interface demonstrating namespace feature.
+#[def_interface(namespace = SimpleNs)]
+pub trait NamespacedIf {
+    /// Get an identifier.
+    fn get_id() -> i32;
+}
+
+/// An interface with gen_caller option.
+#[def_interface(gen_caller)]
+pub trait CallerIf {
+    /// A function that will have a helper caller generated.
+    fn add_one(x: i32) -> i32;
+
+    /// Another function with helper caller.
+    fn multiply(a: i32, b: i32) -> i32;
+}
+
+/// An interface with both namespace and gen_caller.
+#[def_interface(gen_caller, namespace = AdvancedNs)]
+pub trait AdvancedIf {
+    /// Complex computation.
+    fn process(input: u64) -> u64;
+}

--- a/test_crates/define-weak-traits/Cargo.toml
+++ b/test_crates/define-weak-traits/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "define-weak-traits"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+# Don't use workspace dependency here because we want to test the weak_default feature
+crate_interface = { path = "../..", features = ["weak_default"] }

--- a/test_crates/define-weak-traits/src/lib.rs
+++ b/test_crates/define-weak-traits/src/lib.rs
@@ -1,0 +1,84 @@
+//! Define traits with default implementations using weak_default feature.
+//!
+//! This crate defines traits that have default implementations. With the
+//! `weak_default` feature enabled, these default implementations are compiled
+//! as weak symbols, allowing implementors to optionally override them.
+//!
+//! IMPORTANT: This crate requires nightly Rust and `#![feature(linkage)]`.
+
+#![feature(linkage)]
+
+use crate_interface::def_interface;
+
+/// A trait with some methods having default implementations.
+///
+/// Implementors can choose to implement only the required methods (those without
+/// defaults), and the default implementations will be used for the rest via
+/// weak symbol linkage.
+#[def_interface]
+pub trait WeakDefaultIf {
+    /// A required method - must be implemented.
+    fn required_value() -> u32;
+
+    /// A method with default implementation - can be skipped.
+    fn default_value() -> u32 {
+        42
+    }
+
+    /// A method with default implementation that uses arguments.
+    fn default_add(a: u32, b: u32) -> u32 {
+        a + b
+    }
+
+    /// Another required method.
+    fn required_name() -> &'static str;
+
+    /// Default implementation returning a constant string.
+    fn default_greeting() -> &'static str {
+        "Hello from weak default!"
+    }
+}
+
+/// A trait where ALL methods have default implementations.
+/// Implementors can implement an empty impl block (just to register the implementation).
+#[def_interface]
+pub trait AllDefaultIf {
+    /// Default method 1.
+    fn method_a() -> i32 {
+        100
+    }
+
+    /// Default method 2.
+    fn method_b() -> i32 {
+        200
+    }
+
+    /// Default method with computation.
+    fn method_c(x: i32) -> i32 {
+        x * 2
+    }
+}
+
+/// A trait with namespace and default implementations.
+#[def_interface(namespace = WeakNs)]
+pub trait NamespacedWeakIf {
+    /// Required method.
+    fn get_id() -> u64;
+
+    /// Default method.
+    fn get_default_multiplier() -> u64 {
+        10
+    }
+}
+
+/// A trait with gen_caller and default implementations.
+#[def_interface(gen_caller)]
+pub trait CallerWeakIf {
+    /// Required method with helper caller.
+    fn compute(x: i64) -> i64;
+
+    /// Default method with helper caller.
+    fn default_offset() -> i64 {
+        1000
+    }
+}

--- a/test_crates/define-weak-traits/src/lib.rs
+++ b/test_crates/define-weak-traits/src/lib.rs
@@ -82,3 +82,50 @@ pub trait CallerWeakIf {
         1000
     }
 }
+
+/// A trait demonstrating Self::method references in default implementations.
+///
+/// This tests both:
+/// 1. Direct calls: `Self::base_value()` - method called directly
+/// 2. Indirect references: `Self::transform` - method used as a value/function pointer
+///
+/// Both cases are handled uniformly by generating proxy functions.
+#[def_interface]
+pub trait SelfRefIf {
+    /// Base method with default implementation.
+    /// Can be overridden by implementors.
+    fn base_value() -> u32 {
+        100
+    }
+
+    /// Derived method that calls `base_value()` directly.
+    fn derived_value() -> u32 {
+        Self::base_value() * 2
+    }
+
+    /// Derived method using base_value with additional computation.
+    fn derived_with_offset(offset: u32) -> u32 {
+        Self::base_value() + offset
+    }
+
+    /// Transform function that can be overridden.
+    fn transform(v: i32) -> i32 {
+        v + 1
+    }
+
+    /// Method that uses `Self::transform` as a value (indirect reference).
+    fn call_via_ref(v: i32) -> i32 {
+        let f = Self::transform;
+        f(v)
+    }
+
+    /// Method that uses multiple indirect references to the same method.
+    fn call_twice(v: i32) -> i32 {
+        let f1 = Self::transform;
+        let f2 = Self::transform;
+        f2(f1(v))
+    }
+
+    /// Required method to register the impl.
+    fn required_id() -> u32;
+}

--- a/test_crates/impl-simple-traits/Cargo.toml
+++ b/test_crates/impl-simple-traits/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "impl-simple-traits"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+crate_interface.workspace = true
+define-simple-traits.workspace = true

--- a/test_crates/impl-simple-traits/src/lib.rs
+++ b/test_crates/impl-simple-traits/src/lib.rs
@@ -1,0 +1,59 @@
+//! Implement the simple traits defined in `define-simple-traits`.
+//!
+//! This crate demonstrates that trait definition and implementation can be in
+//! separate crates, which is a key feature of `crate_interface`.
+
+use crate_interface::impl_interface;
+use define_simple_traits::{AdvancedIf, CallerIf, NamespacedIf, SimpleIf};
+
+/// Implementation struct for SimpleIf.
+pub struct SimpleImpl;
+
+#[impl_interface]
+impl SimpleIf for SimpleImpl {
+    fn get_value() -> u32 {
+        12345
+    }
+
+    fn compute(a: u32, b: u32) -> u32 {
+        a * b + 10
+    }
+
+    fn get_name() -> &'static str {
+        "SimpleImpl"
+    }
+}
+
+/// Implementation struct for NamespacedIf.
+pub struct NamespacedImpl;
+
+#[impl_interface(namespace = SimpleNs)]
+impl NamespacedIf for NamespacedImpl {
+    fn get_id() -> i32 {
+        999
+    }
+}
+
+/// Implementation struct for CallerIf.
+pub struct CallerImpl;
+
+#[impl_interface]
+impl CallerIf for CallerImpl {
+    fn add_one(x: i32) -> i32 {
+        x + 1
+    }
+
+    fn multiply(a: i32, b: i32) -> i32 {
+        a * b
+    }
+}
+
+/// Implementation struct for AdvancedIf.
+pub struct AdvancedImpl;
+
+#[impl_interface(namespace = AdvancedNs)]
+impl AdvancedIf for AdvancedImpl {
+    fn process(input: u64) -> u64 {
+        input * 2 + 100
+    }
+}

--- a/test_crates/impl-weak-partial/Cargo.toml
+++ b/test_crates/impl-weak-partial/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "impl-weak-partial"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+crate_interface.workspace = true
+define-weak-traits.workspace = true

--- a/test_crates/impl-weak-partial/src/lib.rs
+++ b/test_crates/impl-weak-partial/src/lib.rs
@@ -1,0 +1,28 @@
+//! Partial implementation of WeakDefaultIf trait.
+//!
+//! This crate ONLY implements the required methods, relying entirely on
+//! weak symbol default implementations for the optional methods.
+//!
+//! This is a separate crate from impl-weak-traits to allow testing the
+//! weak symbol mechanism in isolation (without FullImpl's strong symbols).
+
+#![feature(linkage)]
+
+use crate_interface::impl_interface;
+use define_weak_traits::WeakDefaultIf;
+
+/// Partial implementation - only implements required methods.
+pub struct PartialOnlyImpl;
+
+#[impl_interface]
+impl WeakDefaultIf for PartialOnlyImpl {
+    fn required_value() -> u32 {
+        5555
+    }
+
+    fn required_name() -> &'static str {
+        "PartialOnlyImpl"
+    }
+    // default_value(), default_add(), and default_greeting() are NOT implemented.
+    // They will use the weak symbol default implementations from define-weak-traits.
+}

--- a/test_crates/impl-weak-partial/src/lib.rs
+++ b/test_crates/impl-weak-partial/src/lib.rs
@@ -9,7 +9,7 @@
 #![feature(linkage)]
 
 use crate_interface::impl_interface;
-use define_weak_traits::WeakDefaultIf;
+use define_weak_traits::{SelfRefIf, WeakDefaultIf};
 
 /// Partial implementation - only implements required methods.
 pub struct PartialOnlyImpl;
@@ -25,4 +25,19 @@ impl WeakDefaultIf for PartialOnlyImpl {
     }
     // default_value(), default_add(), and default_greeting() are NOT implemented.
     // They will use the weak symbol default implementations from define-weak-traits.
+}
+
+/// Partial implementation of SelfRefIf - does NOT override base_value or transform.
+///
+/// This tests that Self:: references correctly use the default implementations.
+pub struct SelfRefPartialImpl;
+
+#[impl_interface]
+impl SelfRefIf for SelfRefPartialImpl {
+    fn required_id() -> u32 {
+        1
+    }
+    // base_value() is NOT implemented - uses default (100)
+    // transform() is NOT implemented - uses default (v + 1)
+    // All derived methods use default implementations with Self:: references
 }

--- a/test_crates/impl-weak-traits/Cargo.toml
+++ b/test_crates/impl-weak-traits/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "impl-weak-traits"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+crate_interface.workspace = true
+define-weak-traits.workspace = true

--- a/test_crates/impl-weak-traits/src/lib.rs
+++ b/test_crates/impl-weak-traits/src/lib.rs
@@ -9,7 +9,9 @@
 #![feature(linkage)]
 
 use crate_interface::impl_interface;
-use define_weak_traits::{AllDefaultIf, CallerWeakIf, NamespacedWeakIf, WeakDefaultIf};
+use define_weak_traits::{
+    AllDefaultIf, CallerWeakIf, NamespacedWeakIf, SelfRefIf, WeakDefaultIf,
+};
 
 /// Full implementation - overrides ALL methods including defaults.
 /// This creates strong symbols that override the weak symbol defaults.
@@ -71,4 +73,30 @@ impl CallerWeakIf for CallerWeakImpl {
         x * 3
     }
     // default_offset() will use the weak symbol default.
+}
+
+/// Implementation of SelfRefIf that OVERRIDES base_value and transform.
+///
+/// This tests that:
+/// - derived_value() correctly calls the overridden base_value()
+/// - call_via_ref() correctly uses the overridden transform via proxy function
+pub struct SelfRefFullImpl;
+
+#[impl_interface]
+impl SelfRefIf for SelfRefFullImpl {
+    fn required_id() -> u32 {
+        2
+    }
+
+    // Override base_value to return 500 instead of default 100
+    fn base_value() -> u32 {
+        500
+    }
+
+    // Override transform: multiply by 10 instead of adding 1
+    fn transform(v: i32) -> i32 {
+        v * 10
+    }
+    // derived_value(), derived_with_offset(), call_via_ref(), call_twice()
+    // all use default implementations with Self:: references
 }

--- a/test_crates/impl-weak-traits/src/lib.rs
+++ b/test_crates/impl-weak-traits/src/lib.rs
@@ -1,0 +1,74 @@
+//! Full implementation of weak_default traits defined in `define-weak-traits`.
+//!
+//! This crate provides FULL implementations that override ALL methods,
+//! including those with default implementations. This tests that strong
+//! symbols correctly override weak symbol defaults.
+//!
+//! IMPORTANT: This crate requires nightly Rust and `#![feature(linkage)]`.
+
+#![feature(linkage)]
+
+use crate_interface::impl_interface;
+use define_weak_traits::{AllDefaultIf, CallerWeakIf, NamespacedWeakIf, WeakDefaultIf};
+
+/// Full implementation - overrides ALL methods including defaults.
+/// This creates strong symbols that override the weak symbol defaults.
+pub struct FullImpl;
+
+#[impl_interface]
+impl WeakDefaultIf for FullImpl {
+    fn required_value() -> u32 {
+        2000
+    }
+
+    fn required_name() -> &'static str {
+        "FullImpl"
+    }
+
+    // Override the default implementations with strong symbols.
+    fn default_value() -> u32 {
+        99
+    }
+
+    fn default_add(a: u32, b: u32) -> u32 {
+        a * b // Multiply instead of add
+    }
+
+    fn default_greeting() -> &'static str {
+        "Hello from FullImpl override!"
+    }
+}
+
+/// Implementation for AllDefaultIf - overrides some methods.
+pub struct AllDefaultImpl;
+
+#[impl_interface]
+impl AllDefaultIf for AllDefaultImpl {
+    // Override one method with strong symbol
+    fn method_a() -> i32 {
+        111
+    }
+    // method_b() and method_c() will use weak symbol defaults.
+}
+
+/// Implementation for NamespacedWeakIf.
+pub struct NamespacedWeakImpl;
+
+#[impl_interface(namespace = WeakNs)]
+impl NamespacedWeakIf for NamespacedWeakImpl {
+    fn get_id() -> u64 {
+        12345
+    }
+    // get_default_multiplier() will use the weak symbol default.
+}
+
+/// Implementation for CallerWeakIf.
+pub struct CallerWeakImpl;
+
+#[impl_interface]
+impl CallerWeakIf for CallerWeakImpl {
+    fn compute(x: i64) -> i64 {
+        x * 3
+    }
+    // default_offset() will use the weak symbol default.
+}

--- a/test_crates/run_tests.sh
+++ b/test_crates/run_tests.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Run all integration tests for crate_interface.
+#
+# This script runs test binaries for both simple traits (no default implementations)
+# and weak_default traits (with default implementations via weak symbols).
+#
+# Usage:
+#   ./run_tests.sh           # Run all tests
+#   ./run_tests.sh simple    # Run only simple tests (stable Rust)
+#   ./run_tests.sh weak      # Run only weak_default tests (nightly Rust)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo_status() {
+    echo -e "${GREEN}==>${NC} $1"
+}
+
+echo_warning() {
+    echo -e "${YELLOW}WARNING:${NC} $1"
+}
+
+echo_error() {
+    echo -e "${RED}ERROR:${NC} $1"
+}
+
+run_simple_tests() {
+    echo_status "Running simple trait tests (stable Rust compatible)..."
+
+    echo_status "  Building and running test-simple..."
+    cargo run --bin test-simple
+
+    echo_status "Simple trait tests passed!"
+}
+
+run_weak_tests() {
+    echo_status "Running weak_default trait tests (requires nightly Rust)..."
+
+    # Check if we're on nightly
+    if ! rustc --version | grep -q nightly; then
+        echo_warning "Not on nightly Rust. Attempting to use +nightly..."
+        CARGO_CMD="cargo +nightly"
+    else
+        CARGO_CMD="cargo"
+    fi
+
+    echo_status "  Building and running test-weak (full implementation)..."
+    $CARGO_CMD run --bin test-weak
+
+    echo_status "  Building and running test-weak-partial (partial implementation)..."
+    $CARGO_CMD run --bin test-weak-partial
+
+    echo_status "Weak_default trait tests passed!"
+}
+
+run_all_tests() {
+    run_simple_tests
+    echo ""
+    run_weak_tests
+}
+
+# Parse arguments
+case "${1:-all}" in
+    simple)
+        run_simple_tests
+        ;;
+    weak)
+        run_weak_tests
+        ;;
+    all)
+        run_all_tests
+        ;;
+    *)
+        echo "Usage: $0 [simple|weak|all]"
+        echo "  simple  - Run only simple tests (stable Rust)"
+        echo "  weak    - Run only weak_default tests (nightly Rust)"
+        echo "  all     - Run all tests (default)"
+        exit 1
+        ;;
+esac
+
+echo ""
+echo_status "All requested tests completed successfully!"

--- a/test_crates/test-simple/Cargo.toml
+++ b/test_crates/test-simple/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "test-simple"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+crate_interface.workspace = true
+define-simple-traits.workspace = true
+impl-simple-traits.workspace = true

--- a/test_crates/test-simple/src/main.rs
+++ b/test_crates/test-simple/src/main.rs
@@ -1,0 +1,94 @@
+//! Integration tests for simple traits (without weak_default).
+//!
+//! This binary tests that:
+//! 1. Traits can be defined in one crate and implemented in another
+//! 2. call_interface! macro works correctly across crates
+//! 3. Namespaced traits work correctly
+//! 4. gen_caller helper functions work correctly
+//!
+//! Exit code 0 means all tests passed.
+
+use crate_interface::call_interface;
+
+// Import the implementation crate to link the implementations
+use impl_simple_traits::{AdvancedImpl, CallerImpl, NamespacedImpl, SimpleImpl};
+
+// Suppress unused warnings - these are used for linking
+const _: () = {
+    let _ = std::any::type_name::<SimpleImpl>;
+    let _ = std::any::type_name::<NamespacedImpl>;
+    let _ = std::any::type_name::<CallerImpl>;
+    let _ = std::any::type_name::<AdvancedImpl>;
+};
+
+fn test_simple_interface() {
+    assert_eq!(
+        call_interface!(define_simple_traits::SimpleIf::get_value),
+        12345
+    );
+    assert_eq!(
+        call_interface!(define_simple_traits::SimpleIf::compute, 10, 5),
+        60 // 10 * 5 + 10 = 60
+    );
+    assert_eq!(
+        call_interface!(define_simple_traits::SimpleIf::get_name),
+        "SimpleImpl"
+    );
+    println!("  [PASS] test_simple_interface");
+}
+
+fn test_namespaced_interface() {
+    assert_eq!(
+        call_interface!(namespace = SimpleNs, define_simple_traits::NamespacedIf::get_id),
+        999
+    );
+    println!("  [PASS] test_namespaced_interface");
+}
+
+fn test_caller_interface() {
+    assert_eq!(
+        call_interface!(define_simple_traits::CallerIf::add_one, 41),
+        42
+    );
+    assert_eq!(
+        call_interface!(define_simple_traits::CallerIf::multiply, 6, 7),
+        42
+    );
+
+    // Test gen_caller helper functions
+    use define_simple_traits::{add_one, multiply};
+    assert_eq!(add_one(99), 100);
+    assert_eq!(multiply(3, 4), 12);
+    println!("  [PASS] test_caller_interface");
+}
+
+fn test_advanced_interface() {
+    assert_eq!(
+        call_interface!(namespace = AdvancedNs, define_simple_traits::AdvancedIf::process, 50),
+        200 // 50 * 2 + 100 = 200
+    );
+
+    use define_simple_traits::process;
+    assert_eq!(process(100), 300); // 100 * 2 + 100 = 300
+    println!("  [PASS] test_advanced_interface");
+}
+
+fn test_multiple_calls() {
+    for i in 0..10 {
+        let result = call_interface!(define_simple_traits::SimpleIf::compute, i, i);
+        assert_eq!(result, i * i + 10);
+    }
+    println!("  [PASS] test_multiple_calls");
+}
+
+fn main() {
+    println!("Running simple trait tests...");
+
+    test_simple_interface();
+    test_namespaced_interface();
+    test_caller_interface();
+    test_advanced_interface();
+    test_multiple_calls();
+
+    println!("All simple trait tests passed!");
+}

--- a/test_crates/test-weak-partial/Cargo.toml
+++ b/test_crates/test-weak-partial/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "test-weak-partial"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+crate_interface.workspace = true
+define-weak-traits.workspace = true
+impl-weak-partial.workspace = true

--- a/test_crates/test-weak-partial/src/main.rs
+++ b/test_crates/test-weak-partial/src/main.rs
@@ -1,0 +1,87 @@
+//! Integration tests for weak_default traits with PARTIAL implementation only.
+//!
+//! This binary ONLY links PartialOnlyImpl, which does NOT implement:
+//! - default_value()
+//! - default_add()
+//! - default_greeting()
+//!
+//! Therefore, these methods MUST use the weak symbol default implementations.
+//!
+//! Exit code 0 means all tests passed.
+
+#![feature(linkage)]
+
+use crate_interface::call_interface;
+
+// Import the partial implementation crate to link it
+use impl_weak_partial::PartialOnlyImpl;
+
+// Suppress unused warnings - this is used for linking
+const _: () = {
+    let _ = std::any::type_name::<PartialOnlyImpl>;
+};
+
+fn test_required_methods() {
+    assert_eq!(
+        call_interface!(define_weak_traits::WeakDefaultIf::required_value),
+        5555
+    );
+    assert_eq!(
+        call_interface!(define_weak_traits::WeakDefaultIf::required_name),
+        "PartialOnlyImpl"
+    );
+    println!("  [PASS] test_required_methods");
+}
+
+fn test_weak_default_methods() {
+    // These MUST come from weak symbol defaults
+    assert_eq!(
+        call_interface!(define_weak_traits::WeakDefaultIf::default_value),
+        42
+    );
+    assert_eq!(
+        call_interface!(define_weak_traits::WeakDefaultIf::default_add, 10, 20),
+        30
+    );
+    assert_eq!(
+        call_interface!(define_weak_traits::WeakDefaultIf::default_add, 100, 200),
+        300
+    );
+    assert_eq!(
+        call_interface!(define_weak_traits::WeakDefaultIf::default_greeting),
+        "Hello from weak default!"
+    );
+    println!("  [PASS] test_weak_default_methods");
+}
+
+fn test_weak_default_multiple_calls() {
+    for i in 0..10 {
+        let result = call_interface!(define_weak_traits::WeakDefaultIf::default_add, i, i * 2);
+        assert_eq!(result, i + i * 2);
+    }
+    println!("  [PASS] test_weak_default_multiple_calls");
+}
+
+fn test_mixed_required_and_default() {
+    let req_val = call_interface!(define_weak_traits::WeakDefaultIf::required_value);
+    let def_val = call_interface!(define_weak_traits::WeakDefaultIf::default_value);
+    let req_name = call_interface!(define_weak_traits::WeakDefaultIf::required_name);
+    let def_greeting = call_interface!(define_weak_traits::WeakDefaultIf::default_greeting);
+
+    assert_eq!(req_val, 5555);
+    assert_eq!(def_val, 42);
+    assert_eq!(req_name, "PartialOnlyImpl");
+    assert_eq!(def_greeting, "Hello from weak default!");
+    println!("  [PASS] test_mixed_required_and_default");
+}
+
+fn main() {
+    println!("Running weak_default trait tests (partial implementation)...");
+
+    test_required_methods();
+    test_weak_default_methods();
+    test_weak_default_multiple_calls();
+    test_mixed_required_and_default();
+
+    println!("All weak_default trait tests (partial impl) passed!");
+}

--- a/test_crates/test-weak-partial/src/main.rs
+++ b/test_crates/test-weak-partial/src/main.rs
@@ -14,11 +14,12 @@
 use crate_interface::call_interface;
 
 // Import the partial implementation crate to link it
-use impl_weak_partial::PartialOnlyImpl;
+use impl_weak_partial::{PartialOnlyImpl, SelfRefPartialImpl};
 
 // Suppress unused warnings - this is used for linking
 const _: () = {
     let _ = std::any::type_name::<PartialOnlyImpl>;
+    let _ = std::any::type_name::<SelfRefPartialImpl>;
 };
 
 fn test_required_methods() {
@@ -75,6 +76,59 @@ fn test_mixed_required_and_default() {
     println!("  [PASS] test_mixed_required_and_default");
 }
 
+/// Test Self::method references with default base_value and transform.
+///
+/// SelfRefPartialImpl does NOT override base_value or transform, so:
+/// - base_value() should return 100 (default)
+/// - transform(5) should return 6 (default: 5 + 1)
+fn test_self_ref_partial() {
+    // Test direct call: Self::base_value() uses default
+    assert_eq!(
+        call_interface!(define_weak_traits::SelfRefIf::base_value),
+        100
+    );
+
+    // derived_value calls Self::base_value() directly
+    // 100 * 2 = 200
+    assert_eq!(
+        call_interface!(define_weak_traits::SelfRefIf::derived_value),
+        200
+    );
+
+    // derived_with_offset calls Self::base_value() directly
+    // 100 + 50 = 150
+    assert_eq!(
+        call_interface!(define_weak_traits::SelfRefIf::derived_with_offset, 50),
+        150
+    );
+
+    // Test indirect reference: Self::transform as value uses default
+    assert_eq!(
+        call_interface!(define_weak_traits::SelfRefIf::transform, 5),
+        6
+    );
+
+    // call_via_ref uses `let f = Self::transform; f(v)` pattern
+    assert_eq!(
+        call_interface!(define_weak_traits::SelfRefIf::call_via_ref, 5),
+        6
+    );
+
+    // call_twice applies transform twice: (5 + 1) + 1 = 7
+    assert_eq!(
+        call_interface!(define_weak_traits::SelfRefIf::call_twice, 5),
+        7
+    );
+
+    // Verify required_id
+    assert_eq!(
+        call_interface!(define_weak_traits::SelfRefIf::required_id),
+        1
+    );
+
+    println!("  [PASS] test_self_ref_partial");
+}
+
 fn main() {
     println!("Running weak_default trait tests (partial implementation)...");
 
@@ -82,6 +136,7 @@ fn main() {
     test_weak_default_methods();
     test_weak_default_multiple_calls();
     test_mixed_required_and_default();
+    test_self_ref_partial();
 
     println!("All weak_default trait tests (partial impl) passed!");
 }

--- a/test_crates/test-weak/Cargo.toml
+++ b/test_crates/test-weak/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "test-weak"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+crate_interface.workspace = true
+define-weak-traits.workspace = true
+impl-weak-traits.workspace = true

--- a/test_crates/test-weak/src/main.rs
+++ b/test_crates/test-weak/src/main.rs
@@ -1,0 +1,115 @@
+//! Integration tests for weak_default traits with FULL implementations.
+//!
+//! This binary links FullImpl which overrides ALL methods of WeakDefaultIf.
+//! It verifies that strong symbols correctly override weak symbol defaults.
+//!
+//! Exit code 0 means all tests passed.
+
+#![feature(linkage)]
+
+use crate_interface::call_interface;
+
+// Import the implementation crate to link the implementations
+use impl_weak_traits::{AllDefaultImpl, CallerWeakImpl, FullImpl, NamespacedWeakImpl};
+
+// Suppress unused warnings - these are used for linking
+const _: () = {
+    let _ = std::any::type_name::<FullImpl>;
+    let _ = std::any::type_name::<AllDefaultImpl>;
+    let _ = std::any::type_name::<NamespacedWeakImpl>;
+    let _ = std::any::type_name::<CallerWeakImpl>;
+};
+
+fn test_full_impl_required_methods() {
+    assert_eq!(
+        call_interface!(define_weak_traits::WeakDefaultIf::required_value),
+        2000
+    );
+    assert_eq!(
+        call_interface!(define_weak_traits::WeakDefaultIf::required_name),
+        "FullImpl"
+    );
+    println!("  [PASS] test_full_impl_required_methods");
+}
+
+fn test_full_impl_overridden_defaults() {
+    // Strong symbols should win over weak symbols
+    assert_eq!(
+        call_interface!(define_weak_traits::WeakDefaultIf::default_value),
+        99
+    );
+    assert_eq!(
+        call_interface!(define_weak_traits::WeakDefaultIf::default_add, 10, 20),
+        200 // 10 * 20, not 10 + 20
+    );
+    assert_eq!(
+        call_interface!(define_weak_traits::WeakDefaultIf::default_greeting),
+        "Hello from FullImpl override!"
+    );
+    println!("  [PASS] test_full_impl_overridden_defaults");
+}
+
+fn test_all_default_interface() {
+    let a = call_interface!(define_weak_traits::AllDefaultIf::method_a);
+    let b = call_interface!(define_weak_traits::AllDefaultIf::method_b);
+    let c = call_interface!(define_weak_traits::AllDefaultIf::method_c, 5);
+
+    assert_eq!(a, 111); // Strong symbol override
+    assert_eq!(b, 200); // Weak symbol default
+    assert_eq!(c, 10); // Weak symbol default: 5 * 2
+    println!("  [PASS] test_all_default_interface");
+}
+
+fn test_namespaced_weak_interface() {
+    let id = call_interface!(namespace = WeakNs, define_weak_traits::NamespacedWeakIf::get_id);
+    let multiplier =
+        call_interface!(namespace = WeakNs, define_weak_traits::NamespacedWeakIf::get_default_multiplier);
+
+    assert_eq!(id, 12345);
+    assert_eq!(multiplier, 10);
+    println!("  [PASS] test_namespaced_weak_interface");
+}
+
+fn test_caller_weak_interface() {
+    let computed = call_interface!(define_weak_traits::CallerWeakIf::compute, 100);
+    let offset = call_interface!(define_weak_traits::CallerWeakIf::default_offset);
+
+    assert_eq!(computed, 300); // 100 * 3
+    assert_eq!(offset, 1000); // Weak symbol default
+
+    use define_weak_traits::{compute, default_offset};
+    assert_eq!(compute(50), 150);
+    assert_eq!(default_offset(), 1000);
+    println!("  [PASS] test_caller_weak_interface");
+}
+
+fn test_mixed_strong_and_weak() {
+    for i in 1..5 {
+        assert_eq!(
+            call_interface!(define_weak_traits::AllDefaultIf::method_a),
+            111
+        );
+        assert_eq!(
+            call_interface!(define_weak_traits::AllDefaultIf::method_b),
+            200
+        );
+        assert_eq!(
+            call_interface!(define_weak_traits::AllDefaultIf::method_c, i),
+            i * 2
+        );
+    }
+    println!("  [PASS] test_mixed_strong_and_weak");
+}
+
+fn main() {
+    println!("Running weak_default trait tests (full implementation)...");
+
+    test_full_impl_required_methods();
+    test_full_impl_overridden_defaults();
+    test_all_default_interface();
+    test_namespaced_weak_interface();
+    test_caller_weak_interface();
+    test_mixed_strong_and_weak();
+
+    println!("All weak_default trait tests (full impl) passed!");
+}

--- a/tests/test_crate_interface.rs
+++ b/tests/test_crate_interface.rs
@@ -2,9 +2,7 @@ use crate_interface::*;
 
 #[def_interface]
 trait SimpleIf {
-    fn foo() -> u32 {
-        123
-    }
+    fn foo() -> u32;
 
     /// Test comments
     fn bar(a: u16, b: &[u8], c: &str);

--- a/tests/test_weak_default.rs
+++ b/tests/test_weak_default.rs
@@ -1,0 +1,59 @@
+#![cfg(feature = "weak_default")]
+#![cfg_attr(feature = "weak_default", feature(linkage))]
+
+//! Test weak_default feature.
+//!
+//! This test requires nightly Rust and the `weak_default` feature to be enabled.
+//! Run with: cargo +nightly test --features weak_default --test test_weak_default
+//!
+//! Note: Weak symbols are designed for cross-crate usage. When `def_interface` is
+//! in one crate (with weak symbol default impl) and `impl_interface` is in another
+//! crate (with strong symbol), the linker will choose the strong symbol.
+//! In the same crate, the strong symbol will cause a compile-time conflict.
+
+use crate_interface::*;
+
+/// A trait with default implementations.
+/// When `weak_default` feature is enabled, the default implementation will be
+/// generated as a weak symbol, so implementors can choose not to implement it.
+#[def_interface]
+#[allow(dead_code)]
+trait DefaultMethodIf {
+    /// Method with default implementation - implementor may skip this.
+    fn default_method() -> u32 {
+        42
+    }
+
+    /// Method with default implementation that takes arguments.
+    fn default_with_args(a: u32, b: u32) -> u32 {
+        a + b
+    }
+
+    /// Method without default implementation - must be implemented.
+    fn required_method() -> u32;
+}
+
+struct PartialImpl;
+
+/// Only implement the required method, skip the ones with default implementations.
+/// The methods with default implementations are NOT implemented here.
+/// With `weak_default` feature, the weak symbol from def_interface will be used.
+#[impl_interface]
+impl DefaultMethodIf for PartialImpl {
+    fn required_method() -> u32 {
+        100
+    }
+}
+
+#[test]
+fn test_weak_default_methods() {
+    // Call the required method - should return 100 (from PartialImpl)
+    assert_eq!(call_interface!(DefaultMethodIf::required_method), 100);
+
+    // Call the default methods - should return 42 and sum (from weak symbol default impl)
+    assert_eq!(call_interface!(DefaultMethodIf::default_method), 42);
+    assert_eq!(
+        call_interface!(DefaultMethodIf::default_with_args, 10, 20),
+        30
+    );
+}


### PR DESCRIPTION
Currently, the default implementations of methods in crate_interface traits cause some inconsistencies. They:

- Can be called by other default implementations.
- Can be called by the type implementing crate_interface traits.
- Can be ignored when implementing crate_interface traits.
- Can **NOT** be called by `call_interface!`.

It's frustrating in at least two ways: ignoring methods with default implementations in `#[impl_interface]` causes no compiler error, while calling them with `call_interface!` causes link-time errors (instead of calling the default implementations). It violates the principle of least surprise. Take the following snippet as an example:

```rust
#[def_interface]
pub trait If {
    fn a() -> i32 { 42 }
    fn b() -> i32 { Self::a() + 1 } // <- If::a can be used here
    fn c() -> i32;
}

pub struct Impl;

#[impl_interface]
impl If for Impl {
    // <- If::a can be ignored here without any compiler error
    fn b() -> i32 { 998244353 }
    fn c() -> i32 { Self::a() + 2 } // <- If::a can be used here
}

#[test]
fn caller() {
    assert_eq!(<Impl as If>::a(), 42); // <- If::a can be used directly via the implementor type
    assert_eq!(<Impl as If>::b(), 998244353);
    assert_eq!(<Impl as If>::c(), 44);

    assert_eq!(call_interface!(If::a), 42); // <- If::a CAN NOT be used here, link-time error
    assert_eq!(call_interface!(If::b), 998244353);
    assert_eq!(call_interface!(If::c), 44);
}
```

Also, providing default implementations for some crate_interface methods is extremely useful, especially when designing and implementing BSPs.

It's possible to use weak symbols as a solution: the default implementations are wrapped and exported in functions with same signature as the expected implementor and marked as `#[linkage = "weak"]`, allowing the use of them with `call_interface!`, while implementations in `#[impl_interface]` blocks can safely override them. For backward compatibility, this feature is gated by the "weak_default" feature.

Possible drawbacks:
- Required nightly rust and manual enablement of `linkage` , until https://github.com/rust-lang/rust/issues/29603 is stabilized.
- Weak symbols cannot co-exist with strong symbols under the same name in the same Rust crate. As a result, it's impossible to override the default implementation when implementing the crate_interface trait in the same crate where it's defined. It seems OK for real-world scenarios, but makes tests a little bit more complex.

Possible improvements and fixes that can be shipped with this PR:
- Use sub-attributes to explicitly mark which default implementations should be exported.
- Disable all `self`-like receivers in all crate_interface methods.