### PR TITLE
Explicitly reject receivers and generic parameters in crate_interface methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ using the `impl_interface!` attribute macro, and call it using the
 // Define the interface
 #[crate_interface::def_interface]
 pub trait HelloIf {
-    fn hello(&self, name: &str, id: usize) -> String;
+    fn hello(name: &str, id: usize) -> String;
 }
 
 // Implement the interface in any crate
@@ -29,7 +29,7 @@ struct HelloIfImpl;
 
 #[crate_interface::impl_interface]
 impl HelloIf for HelloIfImpl {
-    fn hello(&self, name: &str, id: usize) -> String {
+    fn hello(name: &str, id: usize) -> String {
         format!("Hello, {} {}!", name, id)
     }
 }
@@ -59,7 +59,7 @@ provides a much more ergonomic API.
 // Define the interface with caller generation
 #[crate_interface::def_interface(gen_caller)]
 pub trait HelloIf {
-    fn hello(&self, name: &str, id: usize) -> String;
+    fn hello(name: &str, id: usize) -> String;
 }
 
 // a function to call the interface function is generated here like:
@@ -70,7 +70,7 @@ struct HelloIfImpl;
 
 #[crate_interface::impl_interface]
 impl HelloIf for HelloIfImpl {
-    fn hello(&self, name: &str, id: usize) -> String {
+    fn hello(name: &str, id: usize) -> String {
         format!("Hello, {} {}!", name, id)
     }
 }
@@ -93,14 +93,14 @@ done by adding the `namespace` argument to the `def_interface!`,
 mod a {
     #[crate_interface::def_interface(namespace = ShoppingMall)]
     pub trait HelloIf {
-        fn hello(&self, name: &str, id: usize) -> String;
+        fn hello(name: &str, id: usize) -> String;
     }
 }
 
 mod b {
     #[crate_interface::def_interface(namespace = Restaurant)]
     pub trait HelloIf {
-        fn hello(&self, name: &str, id: usize) -> String;
+        fn hello(name: &str, id: usize) -> String;
     }
 }
 
@@ -111,7 +111,7 @@ mod c {
 
     #[crate_interface::impl_interface(namespace = ShoppingMall)]
     impl a::HelloIf for HelloIfImplA {
-        fn hello(&self, name: &str, id: usize) -> String {
+        fn hello(name: &str, id: usize) -> String {
             format!("Welcome to the mall, {} {}!", name, id)
         }
     }
@@ -119,7 +119,7 @@ mod c {
     struct HelloIfImplB;
     #[crate_interface::impl_interface(namespace = Restaurant)]
     impl b::HelloIf for HelloIfImplB {
-        fn hello(&self, name: &str, id: usize) -> String {
+        fn hello(name: &str, id: usize) -> String {
             format!("Welcome to the restaurant, {} {}!", name, id)
         }
     }
@@ -143,6 +143,18 @@ fn main() {
 
 A few things to keep in mind when using this crate:
 
+- **Methods with receivers are not supported.** Interface functions must not
+  have `self`, `&self`, or `&mut self` parameters. Use associated functions
+  (static methods) instead:
+
+  ```rust,compile_fail
+  # use crate_interface::*;
+  #[def_interface]
+  trait MyIf {
+      fn foo(&self); // error: methods with receiver (self) are not allowed
+  }
+  ```
+
 - Do not implement an interface for multiple types. No matter in the same crate
   or different crates as long as they are linked together, it will cause a
   link-time error due to duplicate symbol definitions.
@@ -159,7 +171,7 @@ The procedural macros in the above example will generate the following code:
 ```rust
 // #[def_interface]
 pub trait HelloIf {
-    fn hello(&self, name: &str, id: usize) -> String;
+    fn hello(name: &str, id: usize) -> String;
 }
 
 #[allow(non_snake_case)]
@@ -175,13 +187,12 @@ struct HelloIfImpl;
 // #[impl_interface]
 impl HelloIf for HelloIfImpl {
     #[inline]
-    fn hello(&self, name: &str, id: usize) -> String {
+    fn hello(name: &str, id: usize) -> String {
         {
             #[inline]
             #[export_name = "__HelloIf_hello"]
             extern "Rust" fn __HelloIf_hello(name: &str, id: usize) -> String {
-                let _impl: HelloIfImpl = HelloIfImpl;
-                _impl.hello(name, id)
+                HelloIfImpl::hello(name, id)
             }
         }
         {
@@ -202,7 +213,7 @@ functions will also be generated. For example, `HelloIf` above will generate:
 
 ```rust
 pub trait HelloIf {
-    fn hello(&self, name: &str, id: usize) -> String;
+    fn hello(name: &str, id: usize) -> String;
 }
 #[doc(hidden)]
 #[allow(non_snake_case)]
@@ -224,7 +235,7 @@ namespace, the generated code will be:
 
 ```rust
 pub trait HelloIf {
-    fn hello(&self, name: &str, id: usize) -> String;
+    fn hello(name: &str, id: usize) -> String;
 }
 #[doc(hidden)]
 #[allow(non_snake_case)]

--- a/README.md
+++ b/README.md
@@ -155,6 +155,17 @@ A few things to keep in mind when using this crate:
   }
   ```
 
+- **Generic parameters are not supported.** Interface functions cannot have
+  generic type parameters, lifetime parameters, or const generic parameters:
+
+  ```rust,compile_fail
+  # use crate_interface::*;
+  #[def_interface]
+  trait MyIf {
+      fn foo<T>(x: T); // error: generic parameters are not allowed
+  }
+  ```
+
 - Do not implement an interface for multiple types. No matter in the same crate
   or different crates as long as they are linked together, it will cause a
   link-time error due to duplicate symbol definitions.

--- a/src/args.rs
+++ b/src/args.rs
@@ -5,16 +5,10 @@ use syn::{
     parenthesized,
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
-    Error, Expr, Ident, Path, Result, Token,
+    Expr, Ident, Path, Result, Token,
 };
 
-fn duplicate_arg_error(ident: &Ident) -> Error {
-    Error::new_spanned(ident, format!("duplicate argument: {}", ident))
-}
-
-fn unknown_arg_error(ident: &Ident) -> Error {
-    Error::new_spanned(ident, format!("unknown argument: {}", ident))
-}
+use crate::errors::{duplicate_arg_error, unknown_arg_error};
 
 const KEY_GEN_CALLER: &str = "gen_caller";
 const KEY_NAMESPACE: &str = "namespace";

--- a/src/def_interface.rs
+++ b/src/def_interface.rs
@@ -1,0 +1,101 @@
+//! The implementation of the [`crate::def_interface`] attribute macro.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse_quote, Error, ItemTrait, TraitItem};
+
+use crate::args::DefInterfaceArgs;
+use crate::errors::generic_not_allowed_error;
+use crate::naming::{
+    alias_guard_name, extern_fn_mod_name, extern_fn_name, extract_caller_args, namespace_guard_name,
+};
+use crate::validator::validate_fn_signature;
+
+/// The implementation of the [`crate::def_interface`] attribute macro.
+pub fn def_interface(
+    mut ast: ItemTrait,
+    macro_arg: DefInterfaceArgs,
+) -> Result<TokenStream, Error> {
+    let trait_name = &ast.ident;
+    let vis = &ast.vis;
+
+    if !ast.generics.params.is_empty() {
+        return Err(generic_not_allowed_error(&ast.generics));
+    }
+
+    let mod_name = extern_fn_mod_name(trait_name);
+
+    let mut extern_fn_list = vec![];
+    let mut callers: Vec<proc_macro2::TokenStream> = vec![];
+    for item in &ast.items {
+        if let TraitItem::Fn(method) = item {
+            let sig = &method.sig;
+            let fn_name = &sig.ident;
+
+            // Validate signature: reject generic parameters and receivers
+            validate_fn_signature(sig)?;
+
+            let extern_fn_name =
+                extern_fn_name(macro_arg.namespace.as_deref(), trait_name, fn_name);
+
+            let mut extern_fn_sig = sig.clone();
+            extern_fn_sig.ident = extern_fn_name.clone();
+
+            extern_fn_list.push(quote! {
+                pub #extern_fn_sig;
+            });
+
+            if macro_arg.gen_caller {
+                let attrs = &method.attrs;
+                let caller_fn_sig = sig.clone();
+                let caller_args = extract_caller_args(sig)?;
+                callers.push(quote! {
+                    #(#attrs)*
+                    #[inline]
+                    #vis #caller_fn_sig {
+                        unsafe { #mod_name :: #extern_fn_name ( #caller_args ) }
+                    }
+                })
+            }
+        }
+    }
+
+    // Enforce no alias is used to implement an interface, as this makes it
+    // possible to link the function called by `call_interface` to an
+    // implementation with a different signature, which is extremely unsound.
+    let alias_guard_name = alias_guard_name(trait_name);
+    let alias_guard = parse_quote!(
+        #[allow(non_upper_case_globals)]
+        #[doc(hidden)]
+        const #alias_guard_name: () = ();
+    );
+    ast.items.push(alias_guard);
+
+    // Enforce namespace matching if a namespace is specified. No default value
+    // should be provided to ensure that `impl_interface` has a namespace
+    // specified when `def_interface` has one.
+    if let Some(ns) = &macro_arg.namespace {
+        let ns_guard_name = namespace_guard_name(ns);
+        let ns_guard = parse_quote!(
+            #[allow(non_upper_case_globals)]
+            #[doc(hidden)]
+            const #ns_guard_name: ();
+        );
+        ast.items.push(ns_guard);
+    }
+
+    Ok(quote! {
+        #ast
+
+        #[doc(hidden)]
+        #[allow(non_snake_case)]
+        #vis mod #mod_name {
+            use super::*;
+            extern "Rust" {
+                #(#extern_fn_list)*
+            }
+        }
+
+        #(#callers)*
+    })
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,18 @@
+//! Error definitions for the crate interface.
+
+use syn::{Error, Generics, Ident};
+
+pub fn duplicate_arg_error(ident: &Ident) -> Error {
+    Error::new_spanned(ident, format!("duplicate argument: {}", ident))
+}
+
+pub fn unknown_arg_error(ident: &Ident) -> Error {
+    Error::new_spanned(ident, format!("unknown argument: {}", ident))
+}
+
+pub fn generic_not_allowed_error(generic: &Generics) -> Error {
+    Error::new_spanned(
+        generic,
+        "generic parameters are not allowed in crate_interface",
+    )
+}

--- a/src/impl_interface.rs
+++ b/src/impl_interface.rs
@@ -1,0 +1,78 @@
+//! The implementation of the [`crate::impl_interface`] attribute macro.
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{parse_quote, Error, ImplItem, ItemImpl, Type};
+
+use crate::args::ImplInterfaceArgs;
+use crate::naming::{alias_guard_name, extern_fn_name, extract_caller_args, namespace_guard_name};
+use crate::validator::validate_fn_signature;
+
+/// The implementation of the [`crate::impl_interface`] attribute macro.
+pub fn impl_interface(
+    mut ast: ItemImpl,
+    macro_arg: ImplInterfaceArgs,
+) -> Result<TokenStream, Error> {
+    let trait_name = if let Some((_, path, _)) = &ast.trait_ {
+        &path.segments.last().unwrap().ident
+    } else {
+        return Err(Error::new_spanned(ast, "expect a trait implementation"));
+    };
+    let impl_name = if let Type::Path(path) = &ast.self_ty.as_ref() {
+        path.path.get_ident().unwrap()
+    } else {
+        return Err(Error::new_spanned(ast, "expect a trait implementation"));
+    };
+
+    for item in &mut ast.items {
+        if let ImplItem::Fn(method) = item {
+            let (attrs, vis, sig, stmts) =
+                (&method.attrs, &method.vis, &method.sig, &method.block.stmts);
+            let fn_name = &sig.ident;
+            let extern_fn_name =
+                extern_fn_name(macro_arg.namespace.as_deref(), trait_name, fn_name).to_string();
+
+            // Validate signature: reject generic parameters and receivers
+            validate_fn_signature(sig)?;
+
+            let mut new_sig = sig.clone();
+            new_sig.ident = format_ident!("{}", extern_fn_name);
+
+            let args = extract_caller_args(sig)?;
+
+            let call_impl = quote! { #impl_name::#fn_name( #args ) };
+
+            let item: TokenStream = quote! {
+                #[inline]
+                #(#attrs)*
+                #vis
+                #sig
+                {
+                    {
+                        #[inline]
+                        #[export_name = #extern_fn_name]
+                        extern "Rust" #new_sig {
+                            #call_impl
+                        }
+                    }
+                    #(#stmts)*
+                }
+            };
+            *method = syn::parse2(item)?;
+        }
+    }
+
+    // generate alias guard to prevent aliasing of trait names
+    let alias_guard_name = alias_guard_name(trait_name);
+    let alias_guard = parse_quote!(const #alias_guard_name: () = (););
+    ast.items.push(alias_guard);
+
+    // generate namespace guard to enforce namespace matching
+    if let Some(ns) = macro_arg.namespace {
+        let ns_guard_name = namespace_guard_name(&ns);
+        let ns_guard = parse_quote!(const #ns_guard_name: () = (););
+        ast.items.push(ns_guard);
+    }
+
+    Ok(quote! { #ast })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,74 +2,21 @@
 
 use proc_macro::TokenStream;
 use proc_macro2::Span;
-use quote::{format_ident, quote};
-use syn::{
-    parse::Error, parse_macro_input, parse_quote, punctuated::Punctuated, token::Comma, Expr,
-    FnArg, Ident, ImplItem, ImplItemFn, ItemImpl, ItemTrait, Pat, PathArguments, PathSegment,
-    TraitItem, Type,
-};
+use quote::quote;
+use syn::{parse::Error, parse_macro_input, ItemImpl, ItemTrait, PathArguments, PathSegment};
 
 mod args;
+mod def_interface;
+mod errors;
+mod impl_interface;
+mod naming;
+mod validator;
 
 use args::{CallInterface, DefInterfaceArgs, ImplInterfaceArgs};
+use naming::{extern_fn_mod_name, extern_fn_name};
 
 fn compiler_error(err: Error) -> TokenStream {
     err.to_compile_error().into()
-}
-
-/// Clone and validate the argument list, rejecting methods with receivers.
-///
-/// Returns `Err(TokenStream)` with a compile error if any argument is a
-/// receiver (`self`, `&self`, `&mut self`).
-/// Returns `Ok` with a cloned argument list if all arguments are typed.
-fn clone_and_validate_args(
-    inputs: &Punctuated<FnArg, Comma>,
-) -> Result<Punctuated<FnArg, Comma>, TokenStream> {
-    let mut args = Punctuated::new();
-    for arg in inputs {
-        match arg {
-            FnArg::Receiver(receiver) => {
-                return Err(compiler_error(Error::new_spanned(
-                    receiver,
-                    "methods with receiver (self) are not allowed in crate_interface",
-                )));
-            }
-            FnArg::Typed(_) => {
-                args.push(arg.clone());
-            }
-        }
-    }
-    Ok(args)
-}
-
-/// Generate a unique identifier to guard against aliasing of trait names.
-fn alias_guard_name(trait_name: &Ident) -> Ident {
-    format_ident!("__MustNotAnAlias__{}", trait_name)
-}
-
-/// Generate a unique identifier to enforce namespace matching between
-/// `def_interface` and `impl_interface`.
-fn namespace_guard_name(namespace: &str) -> Ident {
-    format_ident!("__NamespaceGuard__{}", namespace)
-}
-
-/// Generate the extern function name (the symbol `def_interface` defines and
-/// `impl_interface` implements), based on the optional namespace, trait name,
-/// and function name.
-fn extern_fn_name(namespace: Option<&str>, trait_name: &Ident, fn_name: &Ident) -> Ident {
-    if let Some(ns) = namespace {
-        format_ident!("__{}_{}_{}", ns, trait_name, fn_name)
-    } else {
-        format_ident!("__{}_{}", trait_name, fn_name)
-    }
-}
-
-/// Generate the module name that contains the extern function declarations.
-///
-/// Namespaces are not included here because no two traits can have the same
-/// name in the same module, so the generated module name will always be unique.
-fn extern_fn_mod_name(trait_name: &Ident) -> Ident {
-    format_ident!("__{}_mod", trait_name)
 }
 
 /// Define a crate interface.
@@ -81,10 +28,18 @@ fn extern_fn_mod_name(trait_name: &Ident) -> Ident {
 /// It is not necessary to define it in the same crate as the implementation,
 /// but it is required that these crates are linked together.
 ///
+/// See the [crate-level documentation](crate) for more details.
+///
+/// ## Calling Helper Functions
+///
 /// It is also possible to generate calling helper functions for each interface
 /// function by enabling the `gen_caller` option.
 ///
-/// **Note:** Methods with receivers (`self`, `&self`, `&mut self`) are not
+/// ## Restrictions
+///
+/// ### No Receivers
+///
+/// Methods with receivers (`self`, `&self`, `&mut self`) are not
 /// allowed. Only associated functions (static methods) are supported:
 ///
 /// ```rust,compile_fail
@@ -95,110 +50,27 @@ fn extern_fn_mod_name(trait_name: &Ident) -> Ident {
 /// }
 /// ```
 ///
-/// See the [crate-level documentation](crate) for more details.
+/// ### No Generic Parameters
+///
+/// Generic parameters are not supported. Interface functions cannot
+/// have generic type parameters, lifetime parameters, or const generic
+/// parameters:
+///
+/// ```rust,compile_fail
+/// # use crate_interface::*;
+/// #[def_interface]
+/// trait MyIf {
+///     fn foo<T>(x: T); // error: generic parameters are not allowed
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn def_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
     let macro_arg = syn::parse_macro_input!(attr as DefInterfaceArgs);
+    let ast = syn::parse_macro_input!(item as ItemTrait);
 
-    let mut ast = syn::parse_macro_input!(item as ItemTrait);
-    let trait_name = &ast.ident;
-    let vis = &ast.vis;
-
-    let mod_name = extern_fn_mod_name(trait_name);
-
-    let mut extern_fn_list = vec![];
-    let mut callers: Vec<proc_macro2::TokenStream> = vec![];
-    for item in &ast.items {
-        if let TraitItem::Fn(method) = item {
-            let sig = &method.sig;
-            let fn_name = &sig.ident;
-
-            // Reject methods with receiver (self, &self, &mut self) and extract args
-            let args = match clone_and_validate_args(&method.sig.inputs) {
-                Ok(args) => args,
-                Err(err) => return err,
-            };
-
-            let extern_fn_name =
-                extern_fn_name(macro_arg.namespace.as_deref(), trait_name, fn_name);
-
-            let mut extern_fn_sig = sig.clone();
-            extern_fn_sig.ident = extern_fn_name.clone();
-            extern_fn_sig.inputs = args;
-
-            extern_fn_list.push(quote! {
-                pub #extern_fn_sig;
-            });
-
-            if macro_arg.gen_caller {
-                let attrs = &method.attrs;
-                let mut caller_fn_sig = sig.clone();
-                caller_fn_sig.inputs = Punctuated::new();
-                let mut caller_args: Punctuated<Expr, Comma> = Punctuated::new();
-
-                for arg in &method.sig.inputs {
-                    if let FnArg::Typed(t) = arg {
-                        if let Pat::Ident(arg_ident) = &*t.pat {
-                            caller_fn_sig.inputs.push(arg.clone());
-                            caller_args.push(parse_quote! { #arg_ident });
-                        } else {
-                            return compiler_error(Error::new_spanned(
-                                &t.pat,
-                                "unexpected pattern in function argument",
-                            ));
-                        }
-                    }
-                }
-                callers.push(quote! {
-                    #(#attrs)*
-                    #[inline]
-                    #vis #caller_fn_sig {
-                        unsafe { #mod_name :: #extern_fn_name ( #caller_args ) }
-                    }
-                })
-            }
-        }
-    }
-
-    // Enforce no alias is used to implement an interface, as this makes it
-    // possible to link the function called by `call_interface` to an
-    // implementation with a different signature, which is extremely unsound.
-    let alias_guard_name = alias_guard_name(trait_name);
-    let alias_guard = parse_quote!(
-        #[allow(non_upper_case_globals)]
-        #[doc(hidden)]
-        const #alias_guard_name: () = ();
-    );
-    ast.items.push(alias_guard);
-
-    // Enforce namespace matching if a namespace is specified. No default value
-    // should be provided to ensure that `impl_interface` has a namespace
-    // specified when `def_interface` has one.
-    if let Some(ns) = &macro_arg.namespace {
-        let ns_guard_name = namespace_guard_name(ns);
-        let ns_guard = parse_quote!(
-            #[allow(non_upper_case_globals)]
-            #[doc(hidden)]
-            const #ns_guard_name: ();
-        );
-        ast.items.push(ns_guard);
-    }
-
-    quote! {
-        #ast
-
-        #[doc(hidden)]
-        #[allow(non_snake_case)]
-        #vis mod #mod_name {
-            use super::*;
-            extern "Rust" {
-                #(#extern_fn_list)*
-            }
-        }
-
-        #(#callers)*
-    }
-    .into()
+    def_interface::def_interface(ast, macro_arg)
+        .map(Into::into)
+        .unwrap_or_else(compiler_error)
 }
 
 /// Implement the crate interface for a struct.
@@ -209,6 +81,12 @@ pub fn def_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// It is not necessary to implement it in the same crate as the definition, but
 /// it is required that these crates are linked together.
+///
+/// See the [crate-level documentation](crate) for more details.
+///
+/// ## Restrictions
+///
+/// ### No Alias
 ///
 /// The specified trait name must not be an alias to the originally defined
 /// name; otherwise, it will result in a compile error.
@@ -228,6 +106,8 @@ pub fn def_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
+/// ### No Namespace Mismatch
+///
 /// It's also mandatory to match the namespace if one is specified when defining
 /// the interface. For example, the following will result in a compile error:
 ///
@@ -246,7 +126,9 @@ pub fn def_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// **Note:** Methods with receivers (`self`, `&self`, `&mut self`) are not
+/// ### No Receivers
+///
+/// Methods with receivers (`self`, `&self`, `&mut self`) are not
 /// allowed in the implementation either:
 ///
 /// ```rust,compile_fail
@@ -263,89 +145,31 @@ pub fn def_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// See the [crate-level documentation](crate) for more details.
+/// ### No Generic Parameters
+///
+/// Generic parameters are not supported in the implementation either:
+///
+/// ```rust,compile_fail
+/// # use crate_interface::*;
+/// trait MyIf {
+///     fn foo<T>(x: T);
+/// }
+///
+/// struct MyImpl;
+///
+/// #[impl_interface]
+/// impl MyIf for MyImpl {
+///     fn foo<T>(x: T) {} // error: generic parameters are not allowed
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn impl_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
     let arg = syn::parse_macro_input!(attr as ImplInterfaceArgs);
+    let ast = syn::parse_macro_input!(item as ItemImpl);
 
-    let mut ast = syn::parse_macro_input!(item as ItemImpl);
-    let trait_name = if let Some((_, path, _)) = &ast.trait_ {
-        &path.segments.last().unwrap().ident
-    } else {
-        return compiler_error(Error::new_spanned(ast, "expect a trait implementation"));
-    };
-    let impl_name = if let Type::Path(path) = &ast.self_ty.as_ref() {
-        path.path.get_ident().unwrap()
-    } else {
-        return compiler_error(Error::new_spanned(ast, "expect a trait implementation"));
-    };
-
-    for item in &mut ast.items {
-        if let ImplItem::Fn(method) = item {
-            let (attrs, vis, sig, stmts) =
-                (&method.attrs, &method.vis, &method.sig, &method.block.stmts);
-            let fn_name = &sig.ident;
-            let extern_fn_name =
-                extern_fn_name(arg.namespace.as_deref(), trait_name, fn_name).to_string();
-
-            // Reject methods with receiver (self, &self, &mut self) and extract args
-            let fn_args = match clone_and_validate_args(&sig.inputs) {
-                Ok(args) => args,
-                Err(err) => return err,
-            };
-
-            let mut new_sig = sig.clone();
-            new_sig.ident = format_ident!("{}", extern_fn_name);
-            new_sig.inputs = fn_args;
-
-            let args: Vec<_> = new_sig
-                .inputs
-                .iter()
-                .filter_map(|arg| {
-                    if let FnArg::Typed(ty) = arg {
-                        Some(ty.pat.clone())
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-
-            let call_impl = quote! { #impl_name::#fn_name( #(#args),* ) };
-
-            let item = quote! {
-                #[inline]
-                #(#attrs)*
-                #vis
-                #sig
-                {
-                    {
-                        #[inline]
-                        #[export_name = #extern_fn_name]
-                        extern "Rust" #new_sig {
-                            #call_impl
-                        }
-                    }
-                    #(#stmts)*
-                }
-            }
-            .into();
-            *method = syn::parse_macro_input!(item as ImplItemFn);
-        }
-    }
-
-    // generate alias guard to prevent aliasing of trait names
-    let alias_guard_name = alias_guard_name(trait_name);
-    let alias_guard = parse_quote!(const #alias_guard_name: () = (););
-    ast.items.push(alias_guard);
-
-    // generate namespace guard to enforce namespace matching
-    if let Some(ns) = arg.namespace {
-        let ns_guard_name = namespace_guard_name(&ns);
-        let ns_guard = parse_quote!(const #ns_guard_name: () = (););
-        ast.items.push(ns_guard);
-    }
-
-    quote! { #ast }.into()
+    impl_interface::impl_interface(ast, arg)
+        .map(Into::into)
+        .unwrap_or_else(compiler_error)
 }
 
 /// Call a function in a crate interface.

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -7,7 +7,7 @@ use syn::{
 
 /// Extract the argument list from the function signature to be used by the caller.
 ///
-/// Returns `Err(TokenStream)` with a compile error if any argument is not an identifier.
+/// Returns `Err(Error)` with a compile error if any argument is not an identifier.
 ///
 /// Receivers are ignored because they are already rejected by `validate_fn_signature`.
 ///

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -1,0 +1,60 @@
+//! Naming utilities for the crate interface.
+
+use quote::format_ident;
+use syn::{
+    parse_quote, punctuated::Punctuated, token::Comma, Error, Expr, FnArg, Ident, Pat, Signature,
+};
+
+/// Extract the argument list from the function signature to be used by the caller.
+///
+/// Returns `Err(TokenStream)` with a compile error if any argument is not an identifier.
+///
+/// Receivers are ignored because they are already rejected by `validate_fn_signature`.
+///
+/// Returns `Ok(Punctuated<Expr, Comma>)` with the argument list.
+pub fn extract_caller_args(sig: &Signature) -> Result<Punctuated<Expr, Comma>, Error> {
+    let mut args = Punctuated::new();
+    for arg in &sig.inputs {
+        if let FnArg::Typed(t) = arg {
+            if let Pat::Ident(arg_ident) = &*t.pat {
+                args.push(parse_quote! { #arg_ident });
+            } else {
+                return Err(Error::new_spanned(
+                    &t.pat,
+                    "unexpected pattern in function argument",
+                ));
+            }
+        }
+    }
+    Ok(args)
+}
+
+/// Generate a unique identifier to guard against aliasing of trait names.
+pub fn alias_guard_name(trait_name: &Ident) -> Ident {
+    format_ident!("__MustNotAnAlias__{}", trait_name)
+}
+
+/// Generate a unique identifier to enforce namespace matching between
+/// `def_interface` and `impl_interface`.
+pub fn namespace_guard_name(namespace: &str) -> Ident {
+    format_ident!("__NamespaceGuard__{}", namespace)
+}
+
+/// Generate the extern function name (the symbol `def_interface` defines and
+/// `impl_interface` implements), based on the optional namespace, trait name,
+/// and function name.
+pub fn extern_fn_name(namespace: Option<&str>, trait_name: &Ident, fn_name: &Ident) -> Ident {
+    if let Some(ns) = namespace {
+        format_ident!("__{}_{}_{}", ns, trait_name, fn_name)
+    } else {
+        format_ident!("__{}_{}", trait_name, fn_name)
+    }
+}
+
+/// Generate the module name that contains the extern function declarations.
+///
+/// Namespaces are not included here because no two traits can have the same
+/// name in the same module, so the generated module name will always be unique.
+pub fn extern_fn_mod_name(trait_name: &Ident) -> Ident {
+    format_ident!("__{}_mod", trait_name)
+}

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -6,7 +6,7 @@ use crate::errors::generic_not_allowed_error;
 
 /// Validate the function signature, rejecting generic parameters and receivers.
 ///
-/// Returns `Err(TokenStream)` with a compile error if:
+/// Returns `Err(Error)` with a compile error if:
 /// - The function has generic parameters
 /// - Any argument is a receiver (`self`, `&self`, `&mut self`)
 pub fn validate_fn_signature(sig: &Signature) -> Result<(), Error> {

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1,0 +1,26 @@
+//! Validator utilities for the crate interface.
+
+use syn::{Error, FnArg, Signature};
+
+use crate::errors::generic_not_allowed_error;
+
+/// Validate the function signature, rejecting generic parameters and receivers.
+///
+/// Returns `Err(TokenStream)` with a compile error if:
+/// - The function has generic parameters
+/// - Any argument is a receiver (`self`, `&self`, `&mut self`)
+pub fn validate_fn_signature(sig: &Signature) -> Result<(), Error> {
+    if !sig.generics.params.is_empty() {
+        return Err(generic_not_allowed_error(&sig.generics));
+    }
+
+    for arg in &sig.inputs {
+        if let FnArg::Receiver(receiver) = arg {
+            return Err(Error::new_spanned(
+                receiver,
+                "methods with receiver (self) are not allowed in crate_interface",
+            ));
+        }
+    }
+    Ok(())
+}

--- a/tests/test_crate_interface.rs
+++ b/tests/test_crate_interface.rs
@@ -7,7 +7,7 @@ trait SimpleIf {
     }
 
     /// Test comments
-    fn bar(&self, a: u16, b: &[u8], c: &str);
+    fn bar(a: u16, b: &[u8], c: &str);
 }
 
 struct SimpleIfImpl;
@@ -20,7 +20,7 @@ impl SimpleIf for SimpleIfImpl {
     }
 
     /// Test comments2
-    fn bar(&self, a: u16, b: &[u8], c: &str) {
+    fn bar(a: u16, b: &[u8], c: &str) {
         println!("{} {:?} {}", a, b, c);
         assert_eq!(b[1], 3);
     }
@@ -28,14 +28,14 @@ impl SimpleIf for SimpleIfImpl {
 
 #[def_interface(gen_caller)]
 trait WithCallerIf {
-    fn baz(&self, x: i32) -> i32;
+    fn baz(x: i32) -> i32;
 }
 
 struct WithCallerIfImpl;
 
 #[impl_interface]
 impl WithCallerIf for WithCallerIfImpl {
-    fn baz(&self, x: i32) -> i32 {
+    fn baz(x: i32) -> i32 {
         x + 1
     }
 }


### PR DESCRIPTION
Currently, the receiver args (`self`, `&self`, `&mut self`, etc) is allowed while not actually used in crate_interface methods. Explicitly rejecting them improves the readability and clarity of crate_interface traits.

Also, generic parameters do not work on crate_interface methods, as Rust does not allow generic parameters on extern functions, this PR also introduces better compiler errors for generic parameters.